### PR TITLE
feat: adding optional arg to specify an existing secret

### DIFF
--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -30,8 +30,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:  
           - secretRef:
-              name: wiz-tunnel-client-{{ include "wiz-broker.wizConnectorID" . }}-cfg
+              name: {{ .Values.secretName | default (printf "wiz-tunnel-client-%s-cfg" (include "wiz-broker.wizConnectorID" .))  }}
 
+{{- if not .Values.secretName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -41,4 +42,5 @@ metadata:
 type: Opaque
 stringData:
   {{- include "wiz-broker.wizConnectorSecretData" . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -43,3 +43,6 @@ wizConnector:
   tunnelServerAddress: ""
   tunnelServerPort: ""
   httpProxy: ""
+
+# optional arguments
+secretName:


### PR DESCRIPTION
this is useful for environments that have specific secret management tooling.  If installing
directly from the helm chart it may not be desirable to pass sensitive data as helm vars