### PR TITLE
Refactor code so as the broker pod does not use the default service account

### DIFF
--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-broker/templates/_helpers.tpl
+++ b/wiz-broker/templates/_helpers.tpl
@@ -40,6 +40,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "wiz-broker.rbacServiceAccountName" -}}
+{{- default (printf "%s-%s" (include "wiz-broker.name" .) "rbac") .Values.rbacServiceAccount.name }}
+{{- end }}
+
+{{/*
 Create Wiz connector properties to use
 */}}
 {{- define "wiz-broker.wizConnectorID" -}}

--- a/wiz-broker/templates/_helpers.tpl
+++ b/wiz-broker/templates/_helpers.tpl
@@ -40,7 +40,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for rbac
 */}}
 {{- define "wiz-broker.rbacServiceAccountName" -}}
 {{- default (printf "%s-%s" (include "wiz-broker.name" .) "rbac") .Values.rbacServiceAccount.name }}

--- a/wiz-broker/templates/serviceaccount.yaml
+++ b/wiz-broker/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wiz-broker.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "wiz-broker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "wiz-broker.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/wiz-broker/templates/wiz-rbac.yaml
+++ b/wiz-broker/templates/wiz-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installRbac }}
-{{- $rbacServiceAccountName := .Values.rbacServiceAccount.name -}}
+{{- $rbacServiceAccountName := include "wiz-broker.rbacServiceAccountName" . -}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/wiz-broker/templates/wiz-rbac.yaml
+++ b/wiz-broker/templates/wiz-rbac.yaml
@@ -1,17 +1,5 @@
 {{- if .Values.installRbac }}
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "wiz-broker.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
-  labels:
-    {{- include "wiz-broker.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
----
-apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ .Values.namespace }}

--- a/wiz-broker/templates/wiz-rbac.yaml
+++ b/wiz-broker/templates/wiz-rbac.yaml
@@ -1,19 +1,33 @@
 {{- if .Values.installRbac }}
+{{- $rbacServiceAccountName := .Values.rbacServiceAccount.name -}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $rbacServiceAccountName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "wiz-broker.labels" . | nindent 4 }}
+  {{- with .Values.rbacServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ .Values.namespace }}
-  name: {{ include "wiz-broker.serviceAccountName" . }}-token
+  name: {{ $rbacServiceAccountName }}-token
   labels:
     {{- include "wiz-broker.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/service-account.name: {{ include "wiz-broker.serviceAccountName" . }}
+    kubernetes.io/service-account.name: {{ $rbacServiceAccountName }}
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "wiz-broker.serviceAccountName" . }}
+  name: {{ $rbacServiceAccountName }}
   labels:
     {{- include "wiz-broker.labels" . | nindent 4 }}
 rules:
@@ -24,15 +38,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "wiz-broker.serviceAccountName" . }}
+  name: {{ $rbacServiceAccountName }}
   labels:
     {{- include "wiz-broker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name:  {{ include "wiz-broker.serviceAccountName" . }}
+  name:  {{ $rbacServiceAccountName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "wiz-broker.serviceAccountName" . }}
+  name: {{ $rbacServiceAccountName }}
   namespace: {{ .Values.namespace }}
 {{- end }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -17,7 +17,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  - name: wiz-broker
+  name: wiz-broker
 
 image:
   repository: wizsec/tunnel-client

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -8,12 +8,15 @@ namespace: "kube-system"
 installRbac: false
 installBroker: false
 
+rbacServiceAccount:
+  name: "wiz-kube-connector"
+  annotations: {}
+
 serviceAccount:
   create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  name: "wiz-kube-connector"
 
 image:
   repository: wizsec/tunnel-client

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -17,6 +17,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
+  - name: wiz-broker
 
 image:
   repository: wizsec/tunnel-client

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -9,6 +9,7 @@ installRbac: false
 installBroker: false
 
 serviceAccount:
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
- Update chart version to 0.2.3
- Update values.yaml, to include serviceAccount.create key, defaults to false
- add a new top-level key in values.yaml, `rbacServiceAccount`
- update wiz-rbac.yaml to use the annotations/service account name from the key rbacServiceAccount 
- add a serviceaccount.yaml which will create a service account to be used by the broker pod
- update wiz-broker-deployment.yaml to reference the service account name created by serviceaccount.yaml
