### PR TITLE
Allow to define common labels in charts

### DIFF
--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -40,6 +40,11 @@ helm.sh/chart: {{ include "wiz-admission-controller.chart" . }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{- range $index, $content := .Values.commonLabels }}
+{{ $index }}: {{ tpl $content $ }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/wiz-admission-controller/templates/deployment.yaml
+++ b/wiz-admission-controller/templates/deployment.yaml
@@ -19,7 +19,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "wiz-admission-controller.selectorLabels" . | nindent 8 }}
+        {{/*
+        `labels` includes `selectorLabels`
+        */}}
+        {{- include "wiz-admission-controller.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -42,6 +42,8 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: {{ include "wiz-admission-controller.secretServerCert" . | trim }}
+  labels:
+    {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
     # Using helm hook to create certs only for chart install
     "helm.sh/hook": "pre-install, pre-upgrade"

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
+
 wizApiToken:
   clientId: ""
   clientToken: ""

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -2,9 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Labels applied on all the resources (not used for selection)
-commonLabels: {}
-
 wizApiToken:
   clientId: ""
   clientToken: ""
@@ -97,6 +94,9 @@ secret:
   # The name of the secret to use.
   # If not set, a name is generated using the fullname template
   name: ""
+
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
 
 podAnnotations: {}
 

--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-broker/templates/_helpers.tpl
+++ b/wiz-broker/templates/_helpers.tpl
@@ -22,6 +22,11 @@ helm.sh/chart: {{ include "wiz-broker.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{- range $index, $content := .Values.commonLabels }}
+{{ $index }}: {{ tpl $content $ }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -43,6 +43,8 @@ kind: Secret
 metadata:
   name: wiz-tunnel-client-{{ include "wiz-broker.wizConnectorID" . }}-cfg
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "wiz-broker.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- include "wiz-broker.wizConnectorSecretData" . | nindent 2 }}

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -18,7 +18,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "wiz-broker.selectorLabels" . | nindent 8 }}
+        {{/*
+        `labels` includes `selectorLabels`
+        */}}
+        {{- include "wiz-broker.labels" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -5,6 +5,9 @@
 nameOverride: "wiz-broker"
 namespace: "kube-system"
 
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
+
 installRbac: false
 installBroker: false
 

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -5,9 +5,6 @@
 nameOverride: "wiz-broker"
 namespace: "kube-system"
 
-# Labels applied on all the resources (not used for selection)
-commonLabels: {}
-
 installRbac: false
 installBroker: false
 
@@ -29,6 +26,9 @@ image:
   tag: "latest"
 
 replicaCount: 1
+
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
 
 podAnnotations: {}
 

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -22,6 +22,11 @@ helm.sh/chart: {{ include "wiz-kubernetes-connector.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{- range $index, $content := .Values.commonLabels }}
+{{ $index }}: {{ tpl $content $ }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -23,7 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "wiz-kubernetes-connector.selectorLabels" . | nindent 8 }}
+        {{/*
+        `labels` includes `selectorLabels`
+        */}}
+        {{- include "wiz-kubernetes-connector.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.autoCreateConnector.serviceAccount.name }}
       restartPolicy: "Never"

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -22,7 +22,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "wiz-kubernetes-connector.selectorLabels" . | nindent 8 }}
+        {{/*
+        `labels` includes `selectorLabels`
+        */}}
+        {{- include "wiz-kubernetes-connector.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.broker.serviceAccount.name }}
       securityContext:

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -4,6 +4,9 @@
 
 nameOverride: "wiz-kubernetes-connector"
 
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
+
 image:
   registry: wiziopublic.azurecr.io/wiz-app
   repository: wiz-broker

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -4,9 +4,6 @@
 
 nameOverride: "wiz-kubernetes-connector"
 
-# Labels applied on all the resources (not used for selection)
-commonLabels: {}
-
 image:
   registry: wiziopublic.azurecr.io/wiz-app
   repository: wiz-broker
@@ -75,6 +72,9 @@ broker:
     annotations: {}
     # The name of the service account to use.
     name: "wiz-broker"
+
+# Labels applied on all the resources (not used for selection)
+commonLabels: {}
 
 podAnnotations: {}
 


### PR DESCRIPTION
In this PR I propose to add a new `commonLabels` variable in the charts. This parameter will allow to add additional labels on all the resources, not used for the selection. 

This is particularly useful for cost reporting or resource owner identification 

This PR also fix 2 secrets that did not have the labels