### PR TITLE
Wz 22875 Change flags names

### DIFF
--- a/git-proxy/values.yaml
+++ b/git-proxy/values.yaml
@@ -39,7 +39,7 @@ image:
   namePrefix: wiz-git-proxy
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "8377775-multiarch"
+  tag: "cdf8e3f-multiarch"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -13,4 +13,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.156226"
+appVersion: "2.0.160355"

--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -13,4 +13,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.161027"
+appVersion: "2.0.162274"

--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -13,4 +13,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.160355"
+appVersion: "2.0.161027"

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "wiz-admission-controller.secretApiTokenName" -}}
-{{ coalesce (.Values.secret.name) (printf "%s-%s" .Release.Name "api-token") }}
+{{ coalesce (.Values.wizApiToken.secret.name) (printf "%s-%s" .Release.Name "api-token") }}
 {{- end }}
 
 {{- define "wiz-admission-controller.secretServerCert" -}}

--- a/wiz-admission-controller/templates/deployment.yaml
+++ b/wiz-admission-controller/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           - mountPath: /var/server-certs
             name: server-certs
             readOnly: true
+          {{- with .Values.customVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -68,20 +71,22 @@ spec:
           - "--cluster-external-id={{ .Values.opaWebhook.clusterExternalId }}"
           {{- end }}
           env:
-          - name: WIZ_ADMISSION_CONTROLLER_CLIENT_ID
+          {{- if not .Values.wizApiToken.usePodCustomEnvironmentVariablesFile }}
+          - name: WIZ_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: {{ include "wiz-admission-controller.secretApiTokenName" . | trim }}
                 key: clientId
                 optional: false
-          - name: WIZ_ADMISSION_CONTROLLER_CLIENT_TOKEN
+          - name: WIZ_CLIENT_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "wiz-admission-controller.secretApiTokenName" . | trim }}
                 key: clientToken
                 optional: false
+          {{- end }}
           {{- if .Values.wizApiToken.clientEndpoint }}
-          - name: WIZ_ADMISSION_CONTROLLER_ENV
+          - name: WIZ_ENV
             value: {{ .Values.wizApiToken.clientEndpoint }}
           {{- end }}
           {{- if .Values.httpProxyConfiguration.enabled }}
@@ -104,6 +109,12 @@ spec:
           {{- with .Values.podCustomEnvironmentVariables }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- if .Values.podCustomEnvironmentVariablesFile }}
+          - name: CLI_ENV_FILE
+            value: {{ .Values.podCustomEnvironmentVariablesFile }}
+          - name: USE_CLI_ENV_FILE
+            value: "true"
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -111,6 +122,9 @@ spec:
           secret:
             defaultMode: 444
             secretName: {{ include "wiz-admission-controller.secretServerCert" . | trim }}
+      {{- with .Values.customVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/wiz-admission-controller/templates/secret.yaml
+++ b/wiz-admission-controller/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.create }}
+{{- if .Values.wizApiToken.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
-  {{- with .Values.secret.annotations }}
+  {{- with .Values.wizApiToken.secret.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -6,6 +6,19 @@ wizApiToken:
   clientId: ""
   clientToken: ""
   clientEndpoint: "" # Set custom endpoint (gov for example)
+  
+  secret:
+    # Specifies whether an api token secret should be created
+    # If create is false you need to create it with clientId, clientToken
+    create: true
+    # Annotations to add to the secret
+    annotations: {}
+    # The name of the secret to use.
+    # If not set, a name is generated using the fullname template
+    name: ""
+  
+  # API token should be read from an environment file, which is specified in podCustomEnvironmentVariablesFile
+  usePodCustomEnvironmentVariablesFile: false
 
 httpProxyConfiguration:
   enabled: false
@@ -91,15 +104,7 @@ serviceAccount:
   # If empty, a name is generated using the fullname template
   name: ""
 
-secret:
-  # Specifies whether a api token secret should be created
-  # If create is false you need to create it with clientId, clientToken
-  create: true
-  # The name of the secret to use.
-  # If not set, a name is generated using the fullname template
-  name: ""
-  # Annotations to be set on the secret
-  annotations: {}
+
 
 # Labels applied on all the resources (not used for selection)
 commonLabels: {}
@@ -109,6 +114,7 @@ podAnnotations: {}
 podSecurityContext: {}
 
 podCustomEnvironmentVariables: {}
+podCustomEnvironmentVariablesFile: ""
 
 securityContext:
   capabilities:
@@ -141,8 +147,9 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+customVolumes: []
+customVolumeMounts: []
+
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.160355"
+appVersion: "2.0.160758"

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.160758"
+appVersion: "2.0.162274"

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.150465"
+appVersion: "2.0.160355"

--- a/wiz-kubernetes-connector/templates/NOTES.txt
+++ b/wiz-kubernetes-connector/templates/NOTES.txt
@@ -18,7 +18,7 @@ helm uninstall {{ .Release.Name | quote }} -n {{ .Release.Namespace | quote }}
 kubectl delete secret {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim }} -n {{ .Release.Namespace | quote }}
 {{- end }}
 {{- end }}
-{{- if and .Values.wizApiToken.createSecret .Values.autoCreateConnector.enabled }}
+{{- if and .Values.wizApiToken.secret.create .Values.autoCreateConnector.enabled }}
 kubectl delete secret {{ include "wiz-kubernetes-connector.apiTokenSecretName" . | trim }} -n {{ .Release.Namespace | quote }}
 {{- end }}
 {{- if .Values.clusterReader.installRbac }}

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Secrets names
 */}}
 
 {{- define "wiz-kubernetes-connector.apiTokenSecretName" -}}
-{{ coalesce (.Values.wizApiToken.name) (printf "%s-api-token" .Release.Name) }}
+{{ coalesce (.Values.wizApiToken.secret.name) (printf "%s-api-token" .Release.Name) }}
 {{- end }}
 
 {{- define "wiz-kubernetes-connector.proxySecretName" -}}

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       {{- include "wiz-kubernetes-connector.selectorLabels" . | nindent 6 }}
-  backoffLimit: 5
+  backoffLimit: 1
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -36,6 +36,10 @@ spec:
       restartPolicy: "Never"
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.autoCreateConnector.customVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
         - name: wiz-connector-creator
           securityContext:
@@ -66,17 +70,25 @@ spec:
             {{ end }}
             ]
           env:
-          - name: CREATE_KUBERNETES_CONNECTOR_CLIENT_ID
+          {{- if .Values.autoCreateConnector.podCustomEnvironmentVariablesFile }}
+          - name: CLI_ENV_FILE
+            value: {{ .Values.autoCreateConnector.podCustomEnvironmentVariablesFile }}
+          - name: USE_CLI_ENV_FILE
+            value: "true"
+          {{- end }}
+          {{- if not .Values.wizApiToken.usePodCustomEnvironmentVariablesFile }}
+          - name: WIZ_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: {{ include "wiz-kubernetes-connector.apiTokenSecretName" . | trim }}
                 key: clientId
-          - name: CREATE_KUBERNETES_CONNECTOR_CLIENT_TOKEN
+          - name: WIZ_CLIENT_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "wiz-kubernetes-connector.apiTokenSecretName" . | trim }}
                 key: clientToken
-          - name: CREATE_KUBERNETES_CONNECTOR_ENV
+          {{- end }}
+          - name: WIZ_ENV
             value: {{ .Values.wizApiToken.clientEndpoint | quote }}
           {{- if .Values.httpProxyConfiguration.enabled }}
           - name: HTTP_PROXY
@@ -97,6 +109,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.autoCreateConnector.customVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}            
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/wiz-kubernetes-connector/templates/secrets.yaml
+++ b/wiz-kubernetes-connector/templates/secrets.yaml
@@ -30,7 +30,6 @@ metadata:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     "helm.sh/hook-weight": "-1"
     {{- with .Values.wizApiToken.secret.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/wiz-kubernetes-connector/templates/secrets.yaml
+++ b/wiz-kubernetes-connector/templates/secrets.yaml
@@ -19,7 +19,7 @@ stringData:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.wizApiToken.createSecret .Values.autoCreateConnector.enabled }}
+{{- if and .Values.wizApiToken.secret.create .Values.autoCreateConnector.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -32,7 +32,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     "helm.sh/hook-weight": "-1"
-    {{- with .Values.wizApiToken.annotations }}
+    {{- with .Values.wizApiToken.secret.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 data:

--- a/wiz-kubernetes-connector/templates/service-account-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/service-account-create-connector.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoCreateConnector.enabled }}
+{{- if and .Values.autoCreateConnector.enabled .Values.autoCreateConnector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,6 +12,8 @@ metadata:
   {{- with .Values.autoCreateConnector.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- if and .Values.autoCreateConnector.enabled .Values.autoCreateConnector.serviceAccount.createRbac }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             mountPath: {{ $mountPath }}
             readOnly: true
           {{- with .Values.broker.customVolumeMounts }}
-          {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           args: [
             {{ $connectorDataFilePath }}

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -61,6 +61,18 @@ spec:
             {{ $connectorDataFilePath }}
           ]
           env:
+          - name: WIZ_ENV
+            value: {{ .Values.wizApiToken.clientEndpoint | quote }}
+          - name: WIZ_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "wiz-kubernetes-connector.apiTokenSecretName" . | trim }}
+                key: clientId
+          - name: WIZ_CLIENT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "wiz-kubernetes-connector.apiTokenSecretName" . | trim }}
+                key: clientToken
           {{- if .Values.broker.podCustomEnvironmentVariablesFile }}
           - name: CLI_ENV_FILE
             value: {{ .Values.broker.podCustomEnvironmentVariablesFile }}

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -41,6 +41,9 @@ spec:
             items:
             - key: connectorData
               path: {{ $connectorDataFileName }}
+        {{- with .Values.broker.customVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -51,10 +54,19 @@ spec:
           - name: connector-data
             mountPath: {{ $mountPath }}
             readOnly: true
+          {{- with .Values.broker.customVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           args: [
             {{ $connectorDataFilePath }}
           ]
           env:
+          {{- if .Values.broker.podCustomEnvironmentVariablesFile }}
+          - name: CLI_ENV_FILE
+            value: {{ .Values.broker.podCustomEnvironmentVariablesFile }}
+          - name: USE_CLI_ENV_FILE
+            value: "true"
+          {{- end }}
           - name: TARGET_IP
             value: {{ .Values.broker.targetIp }}
           {{- if .Values.httpProxyConfiguration.enabled }}

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -34,24 +34,34 @@ autoCreateConnector:
 
   serviceAccount:
     create: true
+    createRbac: true
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.
     name: "wiz-auto-create-connector"
+  
+  podCustomEnvironmentVariablesFile: ""
+  
+  customVolumes: []
+  customVolumeMounts: []
 
 wizApiToken:
-  # Specifies whether an api token secret should be created
-  # If create is false you need to create it with clientId, clientToken
-  createSecret: true
-  # Annotations to add to the secret
-  annotations: {}
-  # The name of the secret to use.
-  # If not set, a name is generated using the fullname template
-  name: ""
-  
   clientId: ""
   clientToken: ""
   clientEndpoint: "" # Set custom endpoint (gov for example)
+
+  secret:
+    # Specifies whether an api token secret should be created
+    # If create is false you need to create it with clientId, clientToken
+    create: true
+    # Annotations to add to the secret
+    annotations: {}
+    # The name of the secret to use.
+    # If not set, a name is generated using the fullname template
+    name: ""
+  
+  # API token should be read from an environment file, which is specified in podCustomEnvironmentVariablesFile
+  usePodCustomEnvironmentVariablesFile: false
 
 wizConnector: # Relevant only for broker.enabled = true & autoCreateConnector = false
   # Specifies whether a proxy secret should be created
@@ -80,6 +90,12 @@ broker:
     annotations: {}
     # The name of the service account to use.
     name: "wiz-broker"
+
+  podCustomEnvironmentVariablesFile: ""
+
+  customVolumes: []
+  customVolumeMounts: []
+  
 
 # Labels applied on all the resources (not used for selection)
 commonLabels: {}


### PR DESCRIPTION
### Helm Values Changes

We've made some changes to the helm values, so please note that this is a **breaking change**. Specifically:

- For the admission controller, we've moved the secret values under the `wizApiToken` key.
- For the Kubernetes connector, we've added a `createRbac` flag and moved the `wizApiToken` secret values under the `secret` key.

### Flag Names Update

We've updated the admission controller and broker image to support the same flag names. This will make it easier for you to manage and customize your wiz installations.

### Custom Volumes and Env Files Support

We've added support for custom volumes and custom env files. This means you can now configure your wiz installations to use the volumes and environment variables that work best for your use case.