### PR TITLE
fix connector secret

### DIFF
--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -4,5 +4,5 @@ description: Wiz Broker for tunneling http traffic to Wiz backend
 
 type: application
 
-version: 1.0.0
+version: 1.0.1
 appVersion: "2.0.162274"

--- a/wiz-broker/templates/secrets.yaml
+++ b/wiz-broker/templates/secrets.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 type: Opaque
 stringData:
-  {{- include "wiz-broker.wizConnectorSecretData" . | nindent 2 }}
+  connectorData: {{- include "wiz-broker.wizConnectorSecretData" . | nindent 2 }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
fix connector secret to have `connectorData` key.
When deployed with create-kubernetes-connector, the key is created automatically via create command.
However when consuming from the chart values, the key is missing.