### PR TITLE
Allow for least privileged cluster reader role and PSS restricted pods

### DIFF
--- a/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
+++ b/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
@@ -36,9 +36,79 @@ metadata:
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
 rules:
+{{- if .Values.clusterReader.installLeastPrivileged }}
+## Install least privileged (no secrets access) reader permissions
+- apiGroups: ["*"]
+  resources: [
+    "customresourcedefinitions", 
+    "nodes", 
+    "pods", 
+    "services", 
+    "ingresses", 
+    "endpoints", 
+    "roles", 
+    "rolebindings", 
+    "clusterroles", 
+    "clusterrolebindings", 
+    "ingressclasses", 
+    "replicasets", 
+    "daemonsets", 
+    "statefulsets", 
+    "deployments", 
+    "serviceaccounts", 
+    "namespaces", 
+    "configmaps", 
+    "jobs", 
+    "cronjobs", 
+    "networkpolicies", 
+    "controllerrevisions", 
+    "podsecuritypolicies", 
+    "persistentvolumes", 
+    "persistentvolumeclaims", 
+    "storageclasses", 
+    "dtabs", 
+    "tokenreviews", 
+    "events", 
+    "endpointslices", 
+    "iamusergroups", 
+    "iamidentitymappings", 
+    "iamidentitymappings/status", 
+    "subjectaccessreviews", 
+    "poddisruptionbudgets", 
+    "validatingwebhookconfigurations", 
+    "mutatingwebhookconfigurations", 
+    "volumesnapshots", 
+    "csinodes", 
+    "csidrivers", 
+    "volumeattachments", 
+    "csistoragecapacities", 
+    "volumesnapshotcontents", 
+    "volumesnapshotclassnames", 
+    "leases"
+  ]
+  verbs: ["get","list","watch"]
+- apiGroups: [
+    "networking.istio.io", 
+    "authentication.istio.io", 
+    "rbac.istio.io", 
+    "config.istio.io", 
+    "security.istio.io", 
+    "linkerd.io", 
+    "policy.linkerd.io", 
+    "crd.projectcalico.org", 
+    "apiregistration.k8s.io", 
+    "cluster.k8s.io", 
+    "k8s.nginx.org", 
+    "cis.f5.com"
+  ]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+{{- else -}}
+## Else install broad readonly access
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -15,6 +15,7 @@ image:
 
 clusterReader:
   installRbac: true
+  installLeastPrivileged: true
   serviceAccount:
     create: true
     # Annotations to add to the service account
@@ -104,14 +105,25 @@ broker:
 
 podAnnotations: {}
 
+# Pod - Adhere to PSS restricted
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
+# Container - Adhere to PSS restricted
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000
   allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: 
+      - all
+  seccompProfile:
+    type: RuntimeDefault
 
 resources: 
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -15,7 +15,7 @@ image:
 
 clusterReader:
   installRbac: true
-  installLeastPrivileged: true
+  installLeastPrivileged: true  # No access to read secrets
   serviceAccount:
     create: true
     # Annotations to add to the service account


### PR DESCRIPTION
- Allow for the creation of the cluster reader role without access to secrets.
- Use Pod Security Standards (PSS) restricted as default in the example helm values.yaml 