### PR TITLE
Stable resource names for connector job create/delete

### DIFF
--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.12
+version: 2.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "wiz-kubernetes-connector.name" . }}-create-connector-{{ randNumeric 5  }}
+  name: {{ include "wiz-kubernetes-connector.name" . }}-create-connector
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "wiz-kubernetes-connector.name" . }}-delete-connector-{{ randNumeric 5  }}
+  name: {{ include "wiz-kubernetes-connector.name" . }}-delete-connector
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}


### PR DESCRIPTION
The kubernetes connector templates for the create and delete jobs should use stable names. The `randNumeric` should not be necessary to ensure a new k8s job can be created the next time the helm chart is upgraded/installed. Instead, the existing [helm deletion policy annotation](https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies) should be sufficient. The existing annotation ensures helm deletes the k8s job after it succeeds and before helm creates a new version of the job.

The random value in the name was causing issues with CD tooling that runs an install/upgrade on every sync such as ArgoCD or Tanka. By using a stable name, tooling will be aware the job was already executed. This PR should resolve #137