### PR TITLE
Create self signed certificate with cert-manager

### DIFF
--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -138,7 +138,7 @@ Create the name of the service account to use
 {{- define "wiz-admission-controller.certManagerInject" -}}
 {{- if contains .Values.webhook.injectCaFrom "/" -}}
 {{- .Values.webhook.injectCaFrom -}}
-{{- else -}}
+{{- else if .Values.webhook.injectCaFrom -}}
 {{- printf "%s/%s" .Release.Namespace .Values.webhook.injectCaFrom -}}
 {{- end -}}
 {{- end -}}
@@ -146,7 +146,7 @@ Create the name of the service account to use
 {{- define "wiz-admission-controller.certManagerName" -}}
 {{- if not .Values.webhook.injectCaFrom -}}
 {{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
-{{- if contains .Values.webhook.injectCaFrom "/" -}}
+{{- else if contains .Values.webhook.injectCaFrom "/" -}}
 {{- regexFind ".*/(.*)" .Values.webhook.injectCaFrom -}}
 {{- else -}}
 {{- .Values.webhook.injectCaFrom -}}

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -77,9 +77,9 @@ Create the name of the service account to use
 
 {{- define "wiz-admission-controller.secretServerCert" -}}
 {{- if .Values.webhook.secret.name }}
-{{ .Values.webhook.secret.name }}
+{{- .Values.webhook.secret.name }}
 {{- else }}
-{{ include "wiz-admission-controller.fullname" . }}-cert
+{{- include "wiz-admission-controller.fullname" . }}-cert
 {{- end }}
 {{- end }}
 

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -135,14 +135,6 @@ Create the name of the service account to use
 {{ include "helpers.calculateHash" (list .Values.global.wizApiToken.clientId .Values.global.wizApiToken.clientToken .Values.global.wizApiToken.secret.name .Values.wizApiToken.clientId .Values.wizApiToken.clientToken .Values.wizApiToken.secret.name) }}
 {{- end }}
 
-{{- define "wiz-admission-controller.certManagerInject" -}}
-{{- if contains .Values.webhook.injectCaFrom "/" -}}
-{{- .Values.webhook.injectCaFrom -}}
-{{- else if .Values.webhook.injectCaFrom -}}
-{{- printf "%s/%s" .Release.Namespace .Values.webhook.injectCaFrom -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "wiz-admission-controller.certManagerName" -}}
 {{- if not .Values.webhook.injectCaFrom -}}
 {{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
@@ -150,6 +142,16 @@ Create the name of the service account to use
 {{- regexFind ".*/(.*)" .Values.webhook.injectCaFrom -}}
 {{- else -}}
 {{- .Values.webhook.injectCaFrom -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wiz-admission-controller.certManagerInject" -}}
+{{- if contains .Values.webhook.injectCaFrom "/" -}}
+{{- .Values.webhook.injectCaFrom -}}
+{{- else if .Values.webhook.injectCaFrom -}}
+{{- printf "%s/%s" .Release.Namespace .Values.webhook.injectCaFrom -}}
+{{- else -}}
+{{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -135,11 +135,9 @@ Create the name of the service account to use
 {{ include "helpers.calculateHash" (list .Values.global.wizApiToken.clientId .Values.global.wizApiToken.clientToken .Values.global.wizApiToken.secret.name .Values.wizApiToken.clientId .Values.wizApiToken.clientToken .Values.wizApiToken.secret.name) }}
 {{- end }}
 
-{{- define "wiz-admission-controller.certManagerName" -}}
-{{- if not .Values.webhook.injectCaFrom -}}
-{{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
-{{- else if contains .Values.webhook.injectCaFrom "/" -}}
-{{- regexFind ".*/(.*)" .Values.webhook.injectCaFrom -}}
+{{- define "wiz-admission-controller.certManagerInject" -}}
+{{- if .Values.webhook.createSelfSignedCert -}}
+{{- printf "%s/%s-cert" .Release.Namespace (include "wiz-admission-controller.fullname" .) -}}
 {{- else -}}
 {{- .Values.webhook.injectCaFrom -}}
 {{- end -}}

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -135,6 +135,24 @@ Create the name of the service account to use
 {{ include "helpers.calculateHash" (list .Values.global.wizApiToken.clientId .Values.global.wizApiToken.clientToken .Values.global.wizApiToken.secret.name .Values.wizApiToken.clientId .Values.wizApiToken.clientToken .Values.wizApiToken.secret.name) }}
 {{- end }}
 
+{{- define "wiz-admission-controller.certManagerInject" -}}
+{{- if contains .Values.webhook.injectCaFrom "/" -}}
+{{- .Values.webhook.injectCaFrom -}}
+{{- else -}}
+{{- printf "%s/%s" .Release.Namespace .Values.webhook.injectCaFrom -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wiz-admission-controller.certManagerName" -}}
+{{- if not .Values.webhook.injectCaFrom -}}
+{{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
+{{- if contains .Values.webhook.injectCaFrom "/" -}}
+{{- regexFind ".*/(.*)" .Values.webhook.injectCaFrom -}}
+{{- else -}}
+{{- .Values.webhook.injectCaFrom -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 This function dump the value of a variable and fail the template execution.
 Use for debug purpose only.

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -145,16 +145,6 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{- define "wiz-admission-controller.certManagerInject" -}}
-{{- if contains .Values.webhook.injectCaFrom "/" -}}
-{{- .Values.webhook.injectCaFrom -}}
-{{- else if .Values.webhook.injectCaFrom -}}
-{{- printf "%s/%s" .Release.Namespace .Values.webhook.injectCaFrom -}}
-{{- else -}}
-{{- printf "%s-cert" (include "wiz-admission-controller.fullname" .) -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 This function dump the value of a variable and fail the template execution.
 Use for debug purpose only.

--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.webhook.selfSignedCert }}
+{{ if .Values.webhook.createSelfSignedCert }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.webhook.selfSignedCert }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "wiz-admission-controller.certManagerName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  dnsNames:
+  - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace }}
+  - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace }}
+  duration: 8760h0m0s
+  renewBefore: 360h0m0s
+  secretName: {{ include "wiz-admission-controller.secretServerCert" . }}
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{ end }}

--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -1,26 +1,26 @@
-{{ if .Values.webhook.createSelfSignedCert }}
+{{- if .Values.webhook.createSelfSignedCert -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
-  namespace: {{ .Release.Namespace | quote }}
+  name: "selfsigned-issuer"
+  namespace: {{ .Release.Namespace | quote -}}
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "wiz-admission-controller.certManagerName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ include "wiz-admission-controller.certManagerName" . | quote -}}
+  namespace: {{ .Release.Namespace | quote -}}
 spec:
   dnsNames:
-  - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace }}
-  - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace }}
-  duration: 8760h0m0s
-  renewBefore: 360h0m0s
-  secretName: {{ include "wiz-admission-controller.secretServerCert" . }}
+  - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote -}}
+  - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote -}}
+  duration: "8760h0m0s"
+  renewBefore: "360h0m0s"
+  secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote -}}
   issuerRef:
-    name: selfsigned-issuer
-    kind: Issuer
-    group: cert-manager.io
-{{ end }}
+    name: "selfsigned-issuer"
+    kind: "Issuer"
+    group: "cert-manager.io"
+{{- end -}}

--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -1,26 +1,26 @@
-{{- if .Values.webhook.createSelfSignedCert -}}
+{{ if .Values.webhook.createSelfSignedCert }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "selfsigned-issuer"
-  namespace: {{ .Release.Namespace | quote -}}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "wiz-admission-controller.certManagerName" . | quote -}}
-  namespace: {{ .Release.Namespace | quote -}}
+  name: {{ include "wiz-admission-controller.certManagerName" . | quote }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   dnsNames:
-  - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote -}}
-  - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote -}}
+  - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote }}
+  - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote }}
   duration: "8760h0m0s"
   renewBefore: "360h0m0s"
-  secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote -}}
+  secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote }}
   issuerRef:
     name: "selfsigned-issuer"
     kind: "Issuer"
     group: "cert-manager.io"
-{{- end -}}
+{{ end }}

--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -10,7 +10,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "wiz-admission-controller.certManagerName" . | quote }}
+  name: {{ printf "%s-cert" (include "wiz-admission-controller.fullname" .) | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   dnsNames:
@@ -19,6 +19,11 @@ spec:
   duration: "8760h0m0s"
   renewBefore: "360h0m0s"
   secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote }}
+  secretTemplate:
+    annotations:
+    {{- with (coalesce .Values.webhook.secret.annotations .Values.opaWebhook.secret.annotations) }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   issuerRef:
     name: "selfsigned-issuer"
     kind: "Issuer"

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -1,4 +1,4 @@
-{{- $useCertManagerCerts := .Values.webhook.injectCaFrom -}}
+{{- $useCertManagerCerts := (or .Values.webhook.injectCaFrom .Values.webhook.selfSignedCert) -}}
 {{- $tlsCrt := .Values.tlsCertificate.tlsCertificate -}}
 {{- $tlsKey := .Values.tlsCertificate.tlsKey -}}
 {{- if .Values.tlsCertificate.create -}}
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ .Values.webhook.injectCaFrom }}
+    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" }}
   {{- end }}
 webhooks:
 - name: misconfigurationsadmissionvalidator.wiz.io
@@ -58,7 +58,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ .Values.webhook.injectCaFrom }}
+    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" }}
   {{- end }}
 webhooks:
 - name: imageintegrityadmissionvalidator.wiz.io

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -1,4 +1,4 @@
-{{- $useCertManagerCerts := (or .Values.webhook.injectCaFrom .Values.webhook.selfSignedCert) -}}
+{{- $useCertManagerCerts := (or .Values.webhook.injectCaFrom .Values.webhook.createSelfSignedCert) -}}
 {{- $tlsCrt := .Values.tlsCertificate.tlsCertificate -}}
 {{- $tlsKey := .Values.tlsCertificate.tlsKey -}}
 {{- if .Values.tlsCertificate.create -}}

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" }}
+    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
 webhooks:
 - name: misconfigurationsadmissionvalidator.wiz.io
@@ -58,7 +58,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" }}
+    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
 webhooks:
 - name: imageintegrityadmissionvalidator.wiz.io

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
+    "cert-manager.io/inject-ca-from": {{ printf "%s/%s" .Release.Namespace (include "wiz-admission-controller.certManagerName" .) }}
   {{- end }}
 webhooks:
 - name: misconfigurationsadmissionvalidator.wiz.io
@@ -58,7 +58,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" . }}
+    "cert-manager.io/inject-ca-from": {{ printf "%s/%s" .Release.Namespace (include "wiz-admission-controller.certManagerName" .) }}
   {{- end }}
 webhooks:
 - name: imageintegrityadmissionvalidator.wiz.io

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    "cert-manager.io/inject-ca-from": {{ printf "%s/%s" .Release.Namespace (include "wiz-admission-controller.certManagerName" .) }}
+    "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
 webhooks:
 - name: misconfigurationsadmissionvalidator.wiz.io
@@ -58,7 +58,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    "cert-manager.io/inject-ca-from": {{ printf "%s/%s" .Release.Namespace (include "wiz-admission-controller.certManagerName" .) }}
+    "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
 webhooks:
 - name: imageintegrityadmissionvalidator.wiz.io

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if $useCertManagerCerts }}
-    cert-manager.io/inject-ca-from: {{ include "wiz-admission-controller.certManagerInject" . }}
+    "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
 webhooks:
 - name: misconfigurationsadmissionvalidator.wiz.io

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -55,11 +55,11 @@ webhook:
   policyEnforcementMethod: ""     # AUDIT/ BLOCK (Set this to override any admission policy action)
   clusterExternalId: "" # Wiz cluster external id (required only for on-prem and OKE clusters)
 
-  injectCaFrom: "" # Name of the Certificate resource to use/create. Prerequisite - https://cert-manager.io/docs/installation.
+  injectCaFrom: "" # Inject Certificate to webhook configurations. Format: "namespace/certificate". Prerequisite - https://cert-manager.io/docs/installation.
   createSelfSignedCert: false # Create and use a self-signed certificate using `cert-manager`. Prerequisite - https://cert-manager.io/docs/installation.
   secret:
-    name: "" # Name of the Certificate secret used by the Admission Controller. 
-    annotations: {}
+    name: "" # Name of the Certificate secret.
+    annotations: {} # Annotations of the Certificate secret.
 
 opaWebhook:
   enabled: true

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -54,11 +54,12 @@ webhook:
   errorEnforcementMethod: "AUDIT" # AUDIT/ BLOCK
   policyEnforcementMethod: ""     # AUDIT/ BLOCK (Set this to override any admission policy action)
   clusterExternalId: "" # Wiz cluster external id (required only for on-prem and OKE clusters)
+
+  injectCaFrom: "" # Name of the Certificate resource to use/create. Prerequisite - https://cert-manager.io/docs/installation.
+  selfSignedCert: false # Create and use a self-signed certificate using `cert-manager`. Prerequisite - https://cert-manager.io/docs/installation.
   secret:
-    name: "" # tls secret name
-    annotations: {} 
-  # using cert and secret created by cert-manager
-  injectCaFrom: "" # namespace/certificate-name # https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-certificate-resource
+    name: "" # Name of the Certificate secret used by the Admission Controller. 
+    annotations: {}
 
 opaWebhook:
   enabled: true

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -56,7 +56,7 @@ webhook:
   clusterExternalId: "" # Wiz cluster external id (required only for on-prem and OKE clusters)
 
   injectCaFrom: "" # Name of the Certificate resource to use/create. Prerequisite - https://cert-manager.io/docs/installation.
-  selfSignedCert: false # Create and use a self-signed certificate using `cert-manager`. Prerequisite - https://cert-manager.io/docs/installation.
+  createSelfSignedCert: false # Create and use a self-signed certificate using `cert-manager`. Prerequisite - https://cert-manager.io/docs/installation.
   secret:
     name: "" # Name of the Certificate secret used by the Admission Controller. 
     annotations: {}


### PR DESCRIPTION
Added the option to create a self-signed certificate using cert-manager instead of Helm. This requires cert-manager to be installed.