### PR TITLE
Add cert subject and extend cert duration to 10 years

### DIFF
--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -13,10 +13,13 @@ metadata:
   name: {{ printf "%s-cert" (include "wiz-admission-controller.fullname" .) | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  subject:
+    organizations:
+    - wizselfsigned
   dnsNames:
   - {{ printf "%s.%s" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote }}
   - {{ printf "%s.%s.svc" (include "wiz-admission-controller.fullname" .) .Release.Namespace | quote }}
-  duration: "8760h0m0s"
+  duration: "87600h0m0s" # AC doesn't currently detect changes to the certificate and must be restarted after renewal
   renewBefore: "360h0m0s"
   secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote }}
   secretTemplate:


### PR DESCRIPTION
AC doesn't currently detect changes to the certificate and must be restarted after renewal so we don't want the certificate to expire or the AC will stop functioning. This is the same with the Helm created certificate.

The subject helps get rid of a warning.