### PR TITLE
wiz-broker: Take TLS verification skip and CA certificate out of HTTP proxy configuration

### DIFF
--- a/wiz-broker/templates/_helpers.tpl
+++ b/wiz-broker/templates/_helpers.tpl
@@ -73,6 +73,10 @@ Secrets names
 {{ coalesce (.Values.global.wizApiToken.secret.name) (printf "%s-api-token" .Release.Name) }}
 {{- end }}
 
+{{- define "wiz-broker.caCertificateSecretName" -}}
+{{ coalesce (.Values.global.broker.caCertificate.secretName) (printf "%s-ca-certificate" .Release.Name) }}
+{{- end }}
+
 {{- define "wiz-broker.proxySecretName" -}}
 {{ coalesce (.Values.global.httpProxyConfiguration.secretName) (printf "%s-proxy-configuration" .Release.Name) }}
 {{- end }}

--- a/wiz-broker/templates/secret-proxy.yaml
+++ b/wiz-broker/templates/secret-proxy.yaml
@@ -21,6 +21,4 @@ stringData:
   httpProxy: {{ .Values.global.httpProxyConfiguration.httpProxy | quote }}
   httpsProxy: {{ .Values.global.httpProxyConfiguration.httpsProxy | quote }}
   noProxyAddress: {{ .Values.global.httpProxyConfiguration.noProxyAddress | quote }}
-  caCertificate: {{ .Values.global.httpProxyConfiguration.caCertificate | quote }}
-  skipTlsVerify: {{ .Values.global.httpProxyConfiguration.skipTlsVerify | quote }}
 {{- end }}

--- a/wiz-broker/templates/secrets.yaml
+++ b/wiz-broker/templates/secrets.yaml
@@ -15,6 +15,23 @@ type: Opaque
 data:
   connectorData: {{ include "wiz-broker.wizConnectorSecretData" . | fromYaml | toJson | b64enc | quote }}
 {{- end }}
+
+{{- if and .Values.global.broker.caCertificate.enabled .Values.global.broker.caCertificate.createSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wiz-broker.caCertificateSecretName" . | trim }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "wiz-broker.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.global.broker.caCertificate.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  caCertificate: {{ .Values.global.broker.caCertificate.pem | b64enc | quote }}
+{{- end }}
 {{- end }}
 
 {{- if and .Values.global.wizApiToken.secret.create .Values.global.broker.createSecret }}

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -1,10 +1,9 @@
 {{- if .Values.global.broker.enabled }}
 {{ $mountPath := "/etc/connectorData" }}
-{{ $sslMountPath := "/etc/ssl/certs" }}
 {{ $connectorDataFileName := "data" }}
 {{ $connectorDataFilePath := printf "%s/%s" $mountPath "data" }}
+{{ $sslMountPath := "/etc/ssl/certs" }}
 {{ $customCertificateFileName := "ca-certificates.crt" }}
-{{ $customCertificateFilePath := printf "%s/%s" $sslMountPath $customCertificateFileName }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,9 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{/*
-          `labels` includes `selectorLabels`
-          */}}
+        {{- /* `labels` includes `selectorLabels` */}}
           {{- include "wiz-broker.labels" . | nindent 8 }}
     spec:
       {{- with .Values.global.image.imagePullSecrets }}
@@ -44,10 +41,10 @@ spec:
             items:
               - key: connectorData
                 path: {{ $connectorDataFileName }}
-        {{- if and .Values.global.httpProxyConfiguration.enabled .Values.global.httpProxyConfiguration.caCertificate }}
+        {{- if .Values.global.broker.caCertificate.enabled }}
         - name: ca-certificate
           secret:
-            secretName: {{ include "wiz-broker.proxySecretName" . | trim }}
+            secretName: {{ include "wiz-broker.caCertificateSecretName" . | trim }}
             items:
               - key: caCertificate
                 path: {{ $customCertificateFileName }}
@@ -65,7 +62,7 @@ spec:
           - name: connector-data
             mountPath: {{ $mountPath }}
             readOnly: true
-          {{- if and .Values.global.httpProxyConfiguration.enabled .Values.global.httpProxyConfiguration.caCertificate }}
+          {{- if .Values.global.broker.caCertificate.enabled }}
           - name: ca-certificate
             mountPath: {{ $sslMountPath }}
             readOnly: true
@@ -125,16 +122,14 @@ spec:
                 name: {{ include "wiz-broker.proxySecretName" . | trim }}
                 key: noProxyAddress
                 optional: false
-          - name: DISABLE_TLS_VALIDATION
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "wiz-broker.proxySecretName" . | trim }}
-                key: skipTlsVerify
-                optional: false
-          {{- if .Values.global.httpProxyConfiguration.caCertificate }}
-          - name: CA_CERT_PATH
-            value: {{ $customCertificateFilePath }}
           {{- end }}
+          {{- if .Values.global.broker.skipTlsVerify }}
+          - name: DISABLE_TLS_VALIDATION
+            value: true
+          {{- end }}
+          {{- if .Values.global.broker.caCertificate.enabled }}
+          - name: CA_CERT_PATH
+            value: {{ printf "%s/%s" $sslMountPath $customCertificateFileName }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -44,6 +44,15 @@ global:
     customVolumes: [ ]
     customVolumeMounts: [ ]
 
+    skipTlsVerify: false # true indicates that the proxy's certificate should not be verified. DO NOT USE IN PRODUCTION!
+
+    caCertificate:
+      enabled: false
+      createSecret: true # If false, need to create the secret manually and provide its name in secretName.
+      annotations: { }
+      secretName: ""
+      pem: "" # PEM format CA certificate to use for proxy TLS verification.
+
   httpProxyConfiguration:
     enabled: false
 
@@ -58,8 +67,6 @@ global:
     httpProxy: "" # http(s)://user:password@your-proxy:port (user, password and port are optional)
     httpsProxy: "" # http(s)://user:password@your-proxy:port (user, password and port are optional)
     noProxyAddress: "" # comma or space separated list of machine or domain names
-    skipTlsVerify: "" # true indicates that the proxy's certificate should not be verified. DO NOT USE IN PRODUCTION!
-    caCertificate: "" # pem format CA certificate to use for proxy TLS verification.
 
   wizApiToken:
     clientId: ""
@@ -79,8 +86,8 @@ global:
     # API token should be read from an environment file, which is specified in podCustomEnvironmentVariablesFile
     usePodCustomEnvironmentVariablesFile: false
 
-  wizConnector: # Relevant only for broker.enabled = true & autoCreateConnector = false
-    # Specifies whether a proxy secret should be created
+  wizConnector: # Relevant only for broker.enabled = true
+    # Specifies whether a connector secret should be created
     # If createSecret is false you need to:
     #  1. Create secret with this keys:
     #     CONNECTOR_ID, CONNECTOR_TOKEN, TARGET_DOMAIN, TARGET_IP, TARGET_PORT
@@ -90,7 +97,6 @@ global:
     annotations: {}
     secretName: ""
 
-    # Required arguments for autoCreateConnector = false
     connectorId: ""
     connectorToken: ""
     targetDomain: ""


### PR DESCRIPTION
General idea here is that neither skipping TLS or the certificate are related to the HTTP proxy and shouldn't be coupled with it - So I took them out of that secret and removed the dependency on whether HTTP proxy configuration is enabled to set the environment variable (for skip TLS) or mounting the certificate.