### PR TITLE
Quote common labels in all cases

### DIFF
--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -50,7 +50,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- if .Values.global.commonLabels }}
 {{- range $index, $content := .Values.global.commonLabels }}
-{{ $index }}: {{ tpl $content $ }}
+{{ $index }}: {{ tpl $content $ | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/wiz-broker/templates/_helpers.tpl
+++ b/wiz-broker/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.commonLabels }}
 {{- range $index, $content := .Values.commonLabels }}
-{{ $index }}: {{ tpl $content $ }}
+{{ $index }}: {{ tpl $content $ | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -30,7 +30,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- if .Values.global.commonLabels }}
 {{- range $index, $content := .Values.global.commonLabels }}
-{{ $index }}: {{ tpl $content $ }}
+{{ $index }}: {{ tpl $content $ | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/wiz-kubernetes-integration/templates/_helpers.tpl
+++ b/wiz-kubernetes-integration/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/version: {{ .Values.global.image.tag | default .Chart.AppVersi
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.global.commonLabels }}
 {{- range $index, $content := .Values.global.commonLabels }}
-{{ $index }}: {{ tpl $content $ }}
+{{ $index }}: {{ tpl $content $ | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The bug from #120 got reintroduced with the addition of global common labels.  

I have fixed it again in all the cases where labels were unquoted.