### PR TITLE
Adding code to support image digests without causing label metadata validation errors

### DIFF
--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -40,7 +40,8 @@ Common labels
 helm.sh/chart: {{ include "wiz-admission-controller.chart" . }}
 {{ include "wiz-admission-controller.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- $imageparts:= split "@" .Values.image.tag }}
+app.kubernetes.io/version: {{ $imageparts._0 | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.commonLabels }}

--- a/wiz-sensor/templates/_helpers.tpl
+++ b/wiz-sensor/templates/_helpers.tpl
@@ -36,8 +36,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "wiz-sensor.labels" -}}
+{{- $imageparts:= split "@" .Values.image.tag }}
 helm.sh/chart: {{ include "wiz-sensor.chart" . }}
-image/tag: {{ .Values.image.tag }}
+image/tag: {{ $imageparts._0 }}
 {{ include "wiz-sensor.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
As a security(and env sanity) [best practice](https://cloud.google.com/kubernetes-engine/docs/concepts/about-container-images#:~:text=A%20container%20image%20digest%20uniquely,of%20deploying%20by%20image%20tags.), it is recommended to utilize image digests along with image tags. 

In the current admission-controller and sensor charts, the image digests can be mentioned using "tag" value. However, this value is also used to create the following label's values

'app.kubernetes.io/version' label's value in admission-controller
'image/tag' label's value in sensor

At run time, applying the helm chart cause below error: 
`failed to create default/wiz-sensor-apikey /v1, Kind=Secret for 0d7549fe-XXXXXXXX-caXXXXbe9f1d: Secret "wiz-sensor-apikey" is invalid: [metadata.labels: Invalid value: "1.0.3011@sha256:45b23dee08af5e4XXXXXf9c25ccf269XxXXX3168c19722f87876677c5cb2": must be no more than 63 characters, metadata.labels: Invalid value: "1.0.3011@sha256:45b23dee08af5e43XXXX4cf9c25cXXXXX113168c19722f87876677c5cb2": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]
`

This PR adds a small code to avoid this problem. It picks up the first part from the tag value if a user intends to supply digest along with tag version.

Note: The digest and tag version shown above are just examples and may not refer to an actual version/digest.