### PR TITLE
Add a TTL for the connector Jobs

### DIFF
--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.4
+version: 2.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- end }}   
 
 spec:
+  ttlSecondsAfterFinished: 60
   manualSelector: true
   selector:
     matchLabels:

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- end }} 
 
 spec:
+  ttlSecondsAfterFinished: 60
   manualSelector: true
   selector:
     matchLabels:


### PR DESCRIPTION
When not using Helm, the Jobs remain on the cluster even after they are finished causing future upgrades to fail.
Added a TTL to delete the Jobs after 60 seconds.
When using Helm, the Jobs are deleted right after they are completed.
https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically