### PR TITLE
Allow to run the broker wrapper script in verbose mode

### DIFF
--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -4,5 +4,5 @@ description: Wiz Broker for tunneling http traffic to Wiz backend
 
 type: application
 
-version: 1.0.18
+version: 1.0.19
 appVersion: "2.4"

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -90,6 +90,10 @@ spec:
             {{ $connectorDataFilePath }}
           ]
           env:
+          {{- if .Values.global.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.global.logLevel }}
+          {{- end }}
           - name: WIZ_ENV
             value: {{ .Values.global.wizApiToken.clientEndpoint | quote }}
           {{- if not .Values.global.wizApiToken.usePodCustomEnvironmentVariablesFile }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -12,6 +12,9 @@ podSecurityContext:
   runAsUser: 1000
 
 global:
+  # Set the log level. Can be one of "debug", "info", "warn", or "error".
+  # Warning: Do not set to `debug` in production environments, or sensitive data may be written to the logs.
+  logLevel: "info"
 
   image:
     registry: wiziopublic.azurecr.io/wiz-app

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.8
+version: 2.4.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -85,6 +85,10 @@ spec:
             "--wait={{ and .Values.broker.enabled .Values.autoCreateConnector.waitUntilInitialized }}",
             ]
           env:
+          {{- if .Values.global.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.global.logLevel }}
+          {{- end }}
           {{- with .Values.global.podCustomEnvironmentVariables }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -67,6 +67,10 @@ spec:
             {{- include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote | nindent 12 }},
             ]
           env:
+          {{- if .Values.global.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.global.logLevel }}
+          {{- end }}
           {{- with .Values.global.podCustomEnvironmentVariables }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -69,6 +69,10 @@ spec:
             {{ $connectorDataFilePath }}
           ]
           env:
+          {{- if .Values.global.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.global.logLevel }}
+          {{- end }}
           - name: WIZ_ENV
             value: {{ coalesce .Values.global.wizApiToken.clientEndpoint .Values.wizApiToken.clientEndpoint | quote }}
           {{- with .Values.global.podCustomEnvironmentVariables }}

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -158,6 +158,10 @@ global:
   nameOverride: "" # Override the release’s name.
   commonLabels: {} # Labels applied on all the resources (not used for selection)
 
+  # Set the log level. Can be one of "debug", "info", "warn", or "error".
+  # Warning: Do not set to `debug` in production environments, or sensitive data may be written to the logs.
+  logLevel: "info"
+
   # Wiz Service Account used to authenticate to Wiz.
   wizApiToken:
     clientEndpoint: "" # Wiz endpoint to connect to (required for gov tenants).


### PR DESCRIPTION
Allow to run the broker wrapper script in verbose mode

When we run the broker on our Docker image, we have a wrapper script called:
`/entrypoint.sh`

That script parses various things from the environment and the filesystem
prior to launching the broker.

This script is set to run in "errxit mode" with:
`set -e`

This causes the script to silently fail without emitting its execution commands
and rendering `kubectl logs` empty when things go south (e.g. null TunnelClientAllowedDomains).

This commit allows deploying the Helm chart with verbosity, such that we can run:
`$ kubectl logs wiz-kubernetes-connector-broker-84cb965b9b-6n4qc -n wiz`

and trace its execution to the point it has failed during startup.

The newly added field is `global.broker.logLevel`, which by default is set to 'info'.

To enable it, set the `global.broker.logLevel=debug` in the values, e.g.
```
$ helm install wiz-eks-connector-test \
  ./wiz-kubernetes-connector/ \
  --values values_wiz-kubernetes-connector.yaml \
  --set global.broker.logLevel=debug \
  -n wiz \
  --create-namespace
```