### PR TITLE
Restore the 2024.02.20 chart

### DIFF
--- a/git-proxy/Chart.yaml
+++ b/git-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2024.03.04
+version: 2024.02.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/git-proxy/values.yaml
+++ b/git-proxy/values.yaml
@@ -52,7 +52,7 @@ image:
   namePrefix: wiz-git-proxy
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "afd9bf7-multiarch"
+  tag: "0f032b4-multiarch"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Commit 40cb8e48b5a7df614e69e3e8d614e8c24c18dfc3 changed the git proxy
image in chart version v2024.02.20. Thsi commit reverts this change
as we shouldn't alter a chart's values without incrementing its version.

Once the CI pushes a build of 2024.02.20 this commit should be reverted.