### PR TITLE
Allow disabling the rollme annotation

### DIFF
--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -4,5 +4,5 @@ description: Wiz Broker for tunneling http traffic to Wiz backend
 
 type: application
 
-version: 1.0.19
+version: 1.0.20
 appVersion: "2.4"

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -20,7 +20,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.rollmeAnnotation.enabled }}
         rollme: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -7,6 +7,9 @@ nameOverride: "wiz-broker"
 
 podAnnotations: {}
 
+rollmeAnnotation:
+  enabled: true
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000


### PR DESCRIPTION
This allows those using automated deployment tools such as ArgoCD to avoid unnecessary redeployments.