### PR TITLE
Allow installation in Restricted namespace

### DIFF
--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -114,11 +114,21 @@ podAnnotations: {}
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
+    add:
+    - NET_BIND_SERVICE
+  seccompProfile:
+    type: RuntimeDefault
 
 resources: 
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
When installing Wiz Connector in a cluster that enforces Pod Security Standard Restricted, the following additions have to be made to the Pod and Container SecurityContext. 