### PR TITLE
ClusterReader Fine Grained Access Control

### DIFF
--- a/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
+++ b/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
@@ -36,9 +36,41 @@ metadata:
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["endpoints", "namespaces", "persistentvolumeclaims", "persistentvolumes", "pods", "serviceaccounts", "services", "nodes"]
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources: ["controllerrevisions", "daemonsets", "deployments","replicasets", "statefulsets"]
+    verbs: ["list"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings","clusterroles","rolebindings", "roles"]
+    verbs: ["list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingressclasses", "ingresses", "networkpolicies"]
+    verbs: ["list"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["list"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["gateways","virtualservices"]
+    verbs: ["list"]
+  {{- if .Values.clusterReader.enableListSecret }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -15,6 +15,7 @@ image:
 
 clusterReader:
   installRbac: true
+  enableListSecret: true
   serviceAccount:
     create: true
     # Annotations to add to the service account


### PR DESCRIPTION
The goal of this commit is to allow end users to opt out of `list secrets` using the values file. Instead of having to write a new version of the Cluster Reader role. Because permissions are additive, the commit must first break out the `*` glob permission. Then add a section where the list secret can be enabled with a values boolean. The new boolean is under `clusterReader.enableListSecrets`. 

This is cleaner than expecting users to fork the chart or maintain their own RBAC permissions. 