### PR TITLE
Allow for installation of the admission controller webhooks outside of helm hooks (fixes #315)

### DIFF
--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -17,8 +17,10 @@ metadata:
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
+  {{- if .Values.webhook.installAsHook }}
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   {{- if $useCertManagerCerts }}
     "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
@@ -56,8 +58,10 @@ metadata:
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
+  {{- if .Values.webhook.installAsHook }}
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   {{- if $useCertManagerCerts }}
     "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
@@ -95,8 +99,10 @@ metadata:
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
+  {{- if .Values.webhook.installAsHook }}
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   {{- if $useCertManagerCerts }}
     "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
@@ -134,8 +140,10 @@ metadata:
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
+  {{- if .Values.webhook.installAsHook }}
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   {{- if $useCertManagerCerts }}
     "cert-manager.io/inject-ca-from": {{ include "wiz-admission-controller.certManagerInject" . }}
   {{- end }}
@@ -174,9 +182,11 @@ metadata:
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.webhook.installAsHook }}
     # Using helm hook to create certs only for chart install
     "helm.sh/hook": "pre-install, pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- end }}
     {{- with (coalesce .Values.webhook.secret.annotations .Values.opaWebhook.secret.annotations) }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -58,6 +58,7 @@ webhook:
 
   injectCaFrom: "" # Inject Certificate to webhook configurations. Format: "namespace/certificate". Prerequisite - https://cert-manager.io/docs/installation.
   createSelfSignedCert: false # Create and use a self-signed certificate using `cert-manager`. Prerequisite - https://cert-manager.io/docs/installation.
+  installAsHook: true # Install the webhooks as helm hooks so they are deleted on every install or upgrade.
   secret:
     name: "" # Name of the Certificate secret.
     annotations: {} # Annotations of the Certificate secret.


### PR DESCRIPTION
Small chart change to make the hook installation toggle-able by default.

This ensures that the admission webhooks are not constantly replaced on helm upgrade.

Fixes #315 