### PR TITLE
helm: allow specifying clusterExternalId in the unified chart

### DIFF
--- a/wiz-admission-controller/templates/deploymentauditlogs.yaml
+++ b/wiz-admission-controller/templates/deploymentauditlogs.yaml
@@ -80,7 +80,7 @@ spec:
           # Webhook flags
           - "--error-enforcement-method=AUDIT"
           - "--policy-enforcement-method=AUDIT"
-          - "--cluster-external-id={{ .Values.webhook.clusterExternalId }}"
+          - "--cluster-external-id={{ coalesce .Values.global.clusterExternalId .Values.webhook.clusterExternalId }}"
           # Kubernetes API server flags
           - "--namespace-cache-ttl={{ .Values.kubernetesApiServer.cacheNamespaceLabelsTTL }}"
           # K8S audit logs webhook flags

--- a/wiz-admission-controller/templates/deploymentenforcement.yaml
+++ b/wiz-admission-controller/templates/deploymentenforcement.yaml
@@ -84,7 +84,7 @@ spec:
           {{- with (coalesce .Values.webhook.policyEnforcementMethod .Values.opaWebhook.policyEnforcementMethod) }} # check opaWebhook for backward compatibility
           - "--policy-enforcement-method={{ . }}"
           {{- end }}
-          {{- with (coalesce .Values.webhook.clusterExternalId .Values.opaWebhook.clusterExternalId) }} # check opaWebhook for backward compatibility
+          {{- with (coalesce .Values.global.clusterExternalId .Values.webhook.clusterExternalId .Values.opaWebhook.clusterExternalId) }} # check opaWebhook for backward compatibility
           - "--cluster-external-id={{ . }}"
           {{- end }}
           # Kubernetes API server flags

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -442,3 +442,4 @@ global:
   nodeSelector: {} # custom assignment to nodes
   affinity: {} # custom affinity rules for node assignment
   tolerations: [] # custom tolerations
+  clusterExternalId: "" # Required for OKE clusters - specify the cluster's OCID

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -78,7 +78,7 @@ spec:
             "--service-type",
             {{ . | quote }},
             {{ end }}
-            {{ with .Values.autoCreateConnector.clusterExternalId }}
+            {{ with (coalesce .Values.global.clusterExternalId .Values.autoCreateConnector.clusterExternalId) }}
             "--cluster-external-id",
             {{ . | quote }},
             {{ end }}

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -189,3 +189,4 @@ global:
   nodeSelector: {} # custom assignment to nodes
   affinity: {} # custom affinity rules for node assignment
   tolerations: [] # custom tolerations
+  clusterExternalId: "" # Required for OKE clusters - specify the cluster's OCID

--- a/wiz-kubernetes-integration/values.yaml
+++ b/wiz-kubernetes-integration/values.yaml
@@ -55,6 +55,7 @@ global:
   nodeSelector: {} # custom assignment to nodes
   affinity: {} # custom affinity rules for node assignment
   tolerations: [] # custom tolerations
+  clusterExternalId: "" # Required for OKE clusters - specify the cluster's OCID
 
 # Wiz Kubernetes Connector
 # Configuration values for the wiz-kubernetes-connector dependency


### PR DESCRIPTION
Also use the global setting preferably in AC and connector charts