### PR TITLE
Work around Kubernetes connector Job creation with Istio

### DIFF
--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.13-preview
+version: 3.0.14-preview
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -142,7 +142,7 @@ Use for debug purpose only.
 {{- end -}}
 {{- end }}
 
-{{- define "wiz-kubernetes-connector.generate-args-list-create" -}}
+{{- define "wiz-kubernetes-connector.argsListCreateConnector" -}}
 create-kubernetes-connector
 --api-server-endpoint
 {{ include "wiz-kubernetes-connector.apiServerEndpoint" . | trim | quote }}
@@ -176,8 +176,8 @@ create-kubernetes-connector
 {{- printf "curl --max-time 2 -s -f -XPOST http://127.0.0.1:%d/quitquitquit" (int (.Values.autoCreateConnector.istio.proxySidecarPort | default 15000)) -}}
 {{- end -}}
 
-{{- define "wiz-kubernetes-connector.generate-args-create" -}}
-{{- $args := include "wiz-kubernetes-connector.generate-args-list-create" . | splitList "\n" -}}
+{{- define "wiz-kubernetes-connector.generateArgsCreate" -}}
+{{- $args := include "wiz-kubernetes-connector.argsListCreateConnector" . | splitList "\n" -}}
 {{- if .Values.autoCreateConnector.istio.enabled -}}
 {{- $first := include "wiz-kubernetes.pre-istio-sidecar" . -}}
 {{- $last := include "wiz-kubernetes.post-istio-sidecar" . -}}
@@ -200,7 +200,7 @@ delete-kubernetes-connector
 || true
 {{- end }}
 
-{{- define "wiz-kubernetes-connector.generate-args-delete" -}}
+{{- define "wiz-kubernetes-connector.argsListDeleteConnector" -}}
 {{- $args := include "wiz-kubernetes-connector.generate-args-list-delete" . | splitList "\n" -}}
 {{- $output := "kuku" }}
 {{- if .Values.autoCreateConnector.istio.enabled -}}

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -72,32 +72,31 @@ spec:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ coalesce .Values.global.image.pullPolicy .Values.image.pullPolicy }}
-          command: ["wiz-broker"]
-          args: [
-            "create-kubernetes-connector",
-            "--api-server-endpoint", 
-            {{ include "wiz-kubernetes-connector.apiServerEndpoint" . | trim | quote }},
-            "--secrets-namespace", 
-            {{ .Release.Namespace | quote }},
-            "--service-account-token-secret-name",
-            {{ include "wiz-kubernetes-connector.clusterReaderToken" . | quote }},
-            "--output-secret-name",
-            {{- include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote | nindent 12 }},
-            '--is-on-prem={{ include "wiz-kubernetes-connector.brokerEnabled" . | trim}}',
-            {{ with .Values.autoCreateConnector.connectorName }}
-            "--connector-name",
-            {{ . | quote }},
-            {{ end }}
-            {{ with .Values.autoCreateConnector.clusterFlavor }}
-            "--service-type",
-            {{ . | quote }},
-            {{ end }}
-            {{ with (coalesce .Values.global.clusterExternalId .Values.autoCreateConnector.clusterExternalId) }}
-            "--cluster-external-id",
-            {{ . | quote }},
-            {{ end }}
-            '--wait={{ and (include "wiz-kubernetes-connector.brokerEnabled" . | trim) .Values.autoCreateConnector.waitUntilInitialized }}',
-            ]
+          command: ["sh", "-c"]
+          args:
+            - >
+              {{- if .Values.autoCreateConnector.istio.enabled }}
+              sleep {{ .Values.autoCreateConnector.istio.sleepBeforeJobSecs | default 15 }} &&
+              {{- end }}
+              wiz-broker create-kubernetes-connector
+              --api-server-endpoint {{ include "wiz-kubernetes-connector.apiServerEndpoint" . | trim | quote }}
+              --secrets-namespace {{ .Release.Namespace | quote }}
+              --service-account-token-secret-name {{ include "wiz-kubernetes-connector.clusterReaderToken" . | quote }}
+              --output-secret-name {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote }}
+              --is-on-prem={{ include "wiz-kubernetes-connector.brokerEnabled" . | trim}}
+              {{- with .Values.autoCreateConnector.connectorName }}
+              --connector-name {{ . | quote }}
+              {{- end }}
+              {{- with .Values.autoCreateConnector.clusterFlavor }}
+              --service-type {{ . | quote }}
+              {{- end }}
+              {{- with (coalesce .Values.global.clusterExternalId .Values.autoCreateConnector.clusterExternalId) }}
+              --cluster-external-id {{ . | quote }}
+              {{- end }}
+              --wait={{ and (include "wiz-kubernetes-connector.brokerEnabled" . | trim) .Values.autoCreateConnector.waitUntilInitialized }}
+              {{- if .Values.autoCreateConnector.istio.enabled }}
+              && curl --max-time 2 -s -f -XPOST http://127.0.0.1:{{ .Values.autoCreateConnector.istio.proxySidecarPort | default 15000 }}/quitquitquit
+              {{- end }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -72,31 +72,9 @@ spec:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ coalesce .Values.global.image.pullPolicy .Values.image.pullPolicy }}
-          command: ["sh", "-c"]
-          args:
-            - >
-              {{- if .Values.autoCreateConnector.istio.enabled }}
-              sleep {{ .Values.autoCreateConnector.istio.sleepBeforeJobSecs | default 15 }} &&
-              {{- end }}
-              wiz-broker create-kubernetes-connector
-              --api-server-endpoint {{ include "wiz-kubernetes-connector.apiServerEndpoint" . | trim | quote }}
-              --secrets-namespace {{ .Release.Namespace | quote }}
-              --service-account-token-secret-name {{ include "wiz-kubernetes-connector.clusterReaderToken" . | quote }}
-              --output-secret-name {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote }}
-              --is-on-prem={{ include "wiz-kubernetes-connector.brokerEnabled" . | trim}}
-              {{- with .Values.autoCreateConnector.connectorName }}
-              --connector-name {{ . | quote }}
-              {{- end }}
-              {{- with .Values.autoCreateConnector.clusterFlavor }}
-              --service-type {{ . | quote }}
-              {{- end }}
-              {{- with (coalesce .Values.global.clusterExternalId .Values.autoCreateConnector.clusterExternalId) }}
-              --cluster-external-id {{ . | quote }}
-              {{- end }}
-              --wait={{ and (include "wiz-kubernetes-connector.brokerEnabled" . | trim) .Values.autoCreateConnector.waitUntilInitialized }}
-              {{- if .Values.autoCreateConnector.istio.enabled }}
-              && curl --max-time 2 -s -f -XPOST http://127.0.0.1:{{ .Values.autoCreateConnector.istio.proxySidecarPort | default 15000 }}/quitquitquit
-              {{- end }}
+          command:
+            {{- include "wiz-kubernetes-connector.entrypoint" . | nindent 12 }}
+          args: {{- include "wiz-kubernetes-connector.generate-args-create" . | nindent 12 }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -74,7 +74,7 @@ spec:
           imagePullPolicy: {{ coalesce .Values.global.image.pullPolicy .Values.image.pullPolicy }}
           command:
             {{- include "wiz-kubernetes-connector.entrypoint" . | nindent 12 }}
-          args: {{- include "wiz-kubernetes-connector.generate-args-create" . | nindent 12 }}
+          args: {{- include "wiz-kubernetes-connector.generateArgsCreate" . | nindent 12 }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -59,19 +59,7 @@ spec:
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ coalesce .Values.global.image.pullPolicy .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
-          # Never fail the job if the deletion fails
-          args:
-            - >
-              {{- if .Values.autoCreateConnector.istio.enabled }}
-              sleep {{ .Values.autoCreateConnector.istio.sleepBeforeJobSecs | default 15 }} &&
-              {{- end }}
-              wiz-broker delete-kubernetes-connector
-              --input-secrets-namespace {{ .Release.Namespace | quote }}
-              --input-secret-name {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote }}
-              || true
-              {{- if .Values.autoCreateConnector.istio.enabled }}
-              && curl --max-time 2 -s -f -XPOST http://127.0.0.1:{{ .Values.autoCreateConnector.istio.proxySidecarPort | default 15000 }}/quitquitquit
-              {{- end }}
+          args: {{- include "wiz-kubernetes-connector.generate-args-delete" . | nindent 12 }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -59,7 +59,7 @@ spec:
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ coalesce .Values.global.image.pullPolicy .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
-          args: {{- include "wiz-kubernetes-connector.generate-args-delete" . | nindent 12 }}
+          args: {{- include "wiz-kubernetes-connector.argsListDeleteConnector" . | nindent 12 }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -62,10 +62,16 @@ spec:
           # Never fail the job if the deletion fails
           args:
             - >
+              {{- if .Values.autoCreateConnector.istio.enabled }}
+              sleep {{ .Values.autoCreateConnector.istio.sleepBeforeJobSecs | default 15 }} &&
+              {{- end }}
               wiz-broker delete-kubernetes-connector
               --input-secrets-namespace {{ .Release.Namespace | quote }}
               --input-secret-name {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote }}
               || true
+              {{- if .Values.autoCreateConnector.istio.enabled }}
+              && curl --max-time 2 -s -f -XPOST http://127.0.0.1:{{ .Values.autoCreateConnector.istio.proxySidecarPort | default 15000 }}/quitquitquit
+              {{- end }}
           env:
           {{- if .Values.global.logLevel }}
           - name: LOG_LEVEL

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -55,6 +55,23 @@ autoCreateConnector:
   roleAnnotations: {}
   roleBindingAnnotations: {}
 
+  # Set this to true if you are using Istio in sidecar mode.
+  # When Istio uses sidecars, there are 2 issues when deploying Wiz:
+  # 1) The creation and deletion Jobs never complete (due to istio-proxy sidecar)
+  # 2) There is a race condition and possible network connectivity failures
+  #    when contacting the Wiz backend.
+  #
+  # When either of this happens, either the installation, upgrade or uninstallation
+  # of the charts fail.
+  # Setting this to true ensures that the istio-proxy gets a graceful shutdown
+  # and mitigates the networking race condition by sleeping before the Job starts.
+  # Learn more:
+  # https://istio.io/latest/blog/2023/native-sidecars/
+  istio:
+    enabled: false
+    sleepBeforeJobSecs: 15
+    proxySidecarPort: 15000
+
 wizApiToken:
   clientId: "" # Client ID of the Wiz Service Account.
   clientToken: "" # Client secret of the Wiz Service Account.


### PR DESCRIPTION
When Istio is deployed on a Kubernetes cluster in sidecar mode there are 2 issues that we may see:

1. The creation and deletion Jobs never complete (due to istio-proxy sidecar)
2. There is a race condition and possible network connectivity failures when contacting the Wiz backend.

When either of this happens, either the installation, upgrade or uninstallation of the charts fail (the jobs never complete).

This commit allows to work around this by setting in user-supplied values.yaml:
`autoCreateConnector.istio.enabled` to `true`

More information:
https://istio.io/latest/blog/2023/native-sidecars/