### PR TITLE
Added a work-around for deploying OpenShift

### DIFF
--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -42,7 +42,11 @@ spec:
       serviceAccountName: {{ .Values.autoCreateConnector.serviceAccount.name }}
       restartPolicy: "Never"
       securityContext:
+        {{- if .Values.useOpenshiftSecurityContexts }}
+        {{- toYaml .Values.openshiftPodSecurityContext | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       {{- if or .Values.autoCreateConnector.customVolumes  .Values.global.customVolumes}}
       volumes:
       {{ with .Values.global.customVolumes }}
@@ -55,7 +59,11 @@ spec:
       containers:
         - name: wiz-connector-creator
           securityContext:
+            {{- if .Values.useOpenshiftSecurityContexts }}
+            {{- toYaml .Values.openshiftSecurityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["wiz-broker"]

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -42,7 +42,11 @@ spec:
       serviceAccountName: {{ .Values.autoCreateConnector.serviceAccount.name }}
       restartPolicy: "Never"
       securityContext:
+        {{- if .Values.useOpenshiftSecurityContexts }}
+        {{- toYaml .Values.openshiftPodSecurityContext | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       {{- if or .Values.autoCreateConnector.customVolumes  .Values.global.customVolumes}}
       volumes:
       {{ with .Values.global.customVolumes }}
@@ -55,7 +59,11 @@ spec:
       containers:
         - name: wiz-connector-delete
           securityContext:
+            {{- if .Values.useOpenshiftSecurityContexts }}
+            {{- toYaml .Values.openshiftSecurityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["wiz-broker"]

--- a/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
+++ b/wiz-kubernetes-connector/templates/wiz-broker-deployment.yaml
@@ -35,7 +35,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ .Values.broker.serviceAccount.name }}
       securityContext:
+        {{- if .Values.useOpenshiftSecurityContexts }}
+        {{- toYaml .Values.openshiftPodSecurityContext | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       volumes:
         - name: connector-data
           secret:
@@ -52,7 +56,11 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
+            {{- if .Values.useOpenshiftSecurityContexts }}
+            {{- toYaml .Values.openshiftSecurityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ coalesce .Values.global.image.repository .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -120,6 +120,14 @@ securityContext:
   runAsUser: 1000
   allowPrivilegeEscalation: false
 
+openshiftPodSecurityContext:
+  runAsNonRoot: true
+
+openshiftSecurityContext:
+  runAsNonRoot: true
+
+useOpenshiftSecurityContexts: false
+
 resources: 
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/wiz-kubernetes-integration/Chart.yaml
+++ b/wiz-kubernetes-integration/Chart.yaml
@@ -8,7 +8,8 @@ appVersion: ""
 # Dependencies for wiz-kubernetes connector and wiz-admission-controller and wiz-sensor
 dependencies:
 - name: wiz-kubernetes-connector
-  repository: https://wiz-sec.github.io/charts
+  #repository: https://wiz-sec.github.io/charts
+  repository: "file://../wiz-kubernetes-connector"
   version: ">=2.2.8"
   condition: wiz-kubernetes-connector.enabled
 - name: "wiz-admission-controller"


### PR DESCRIPTION
The hardcoded uid 1000 is problematic (the toil) in OpenShift deployments where arbitrary uid's are generated for projects.

From the documentation [1]:
"When a Pod is deployed into the namespace, by default, OpenShift will use
 the first UID and first GID from this range to run the Pod."

To enable the work-around, do the following:

wiz-kubernetes-connector:
  useOpenshiftSecurityContexts: true

useOpenshiftSecurityContexts: true

[1] https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids