### PR TITLE
Allow local image.registry override

### DIFF
--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -180,13 +180,13 @@ httpProxyConfiguration:
 # Global values to override chart values.
 global:
   image:
-    registry: wiziopublic.azurecr.io/wiz-app
+    registry: ""
     # Use this if you are deploying on federal environments with FIPS endpoints.
     # repository: wiz-broker-fips
-    repository: wiz-broker
+    # repository: wiz-broker
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    # tag: ""
   imagePullSecrets: [] # Secrets for container image registry keys as described in https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
 
   nameOverride: "" # Override the release’s name.


### PR DESCRIPTION
The [values.yaml](https://github.com/wiz-sec/charts/blob/master/wiz-kubernetes-connector/values.yaml) file populates both the global and "local" image references, which forces the [job-create-connector.yaml](https://github.com/wiz-sec/charts/blob/master/wiz-kubernetes-connector/templates/job-create-connector.yaml) template to reference an incorrect image in case both the registry and repository were customized by a customer, as the template always picks up the global.images.repository predefined "wiz-broker" value, unless it has been overridden, which is going to impact the rest of the templates if they are sourced from different repositories.