### PR TITLE
Add Horizontal Pod Autoscaling (HPA) support to Wiz AC

### DIFF
--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.0
+version: 3.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -40,6 +40,11 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "wiz-hpa.name" -}}
+{{- $name := "wiz-hpa" }}
+{{- default $name .Values.hpa.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -99,6 +104,19 @@ app.kubernetes.io/name: {{ include "wiz-kubernetes-audit-log-collector.name" . }
 {{- define "wiz-kubernetes-audit-log-collector.labels" -}}
 {{ include "wiz-admission-controller.labels" . }}
 {{ include "wiz-kubernetes-audit-log-collector.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Wiz Horizontal Pod Autoscaler selector labels
+*/}}
+
+{{- define "wiz-hpa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wiz-hpa.name" . }}
+{{- end }}
+
+{{- define "wiz-hpa.labels" -}}
+{{ include "wiz-admission-controller.labels" . }}
+{{ include "wiz-hpa.selectorLabels" . }}
 {{- end }}
 
 {{/*

--- a/wiz-admission-controller/templates/deploymentauditlogs.yaml
+++ b/wiz-admission-controller/templates/deploymentauditlogs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "wiz-kubernetes-audit-log-collector.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    {{- include "wiz-kubernetes-audit-log-collector.labels" . | nindent 4 }}
+    {{- include "wiz-hpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.kubernetesAuditLogsWebhook.replicaCount }}
   selector:

--- a/wiz-admission-controller/templates/deploymentenforcement.yaml
+++ b/wiz-admission-controller/templates/deploymentenforcement.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "wiz-admission-controller-enforcement.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "wiz-admission-controller.selectorLabels" . | nindent 6 }}
@@ -209,9 +211,17 @@ spec:
           {{- if .Values.debugWebhook.enabled }}
           - name: WIZ_DEBUG_WEBHOOK_ENABLED
             value: "true"
-          {{- end }}        
+          {{- end }}
           resources:
+            {{- if .Values.hpa.enabled }}
+            {{- if hasKey .Values.hpa "customResources" }}
+            {{- toYaml .Values.hpa.customResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.hpa.defaultResources | nindent 12 }}
+            {{- end }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           volumeMounts:
           - mountPath: /var/cache
             name: cache

--- a/wiz-admission-controller/templates/hpa.yaml
+++ b/wiz-admission-controller/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "wiz-hpa.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wiz-hpa.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "wiz-admission-controller.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.enableCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.enableMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if hasKey .Values.hpa "customMetrics" }}
+    {{- toYaml .Values.hpa.customMetrics | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -426,6 +426,32 @@ probes: # Probes config for the container
     timeoutSeconds: 30
     failureThreshold: 3
 
+# Horizontal Pod Autoscaling support.
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  enableCPU: true
+  targetCPUUtilizationPercentage: 50
+  enableMemory: false
+  targetMemoryUtilizationPercentage: 50
+  customMetrics: []
+
+  # When using HPA, Wiz Helm Charts process the requests and limits
+  # for the Wiz Admission Controller deployment in the following order:
+  # customResources -> defaultResources
+  #
+  # Populating the following `customResources` in your user-supplied values.yaml
+  # allows you to customize and override the `defaultResources`.
+  #
+  # customResources: {}
+
+  defaultResources:
+    requests:
+      cpu: 500m
+      memory: 300Mi
+
+
 # Global values to override chart values.
 global:
   nameOverride: "" # Override the release’s name.


### PR DESCRIPTION
By default this is disabled.

Prerequisites: metrics-server installed on the cluster: https://github.com/kubernetes-sigs/metrics-server

To enable HPA, set:
```
wiz-admission-controller:
  hpa:
    enabled: true
```