### PR TITLE
Add coalesce to use both .Values.global and .Values tolerations in wiz-broker

### DIFF
--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -173,7 +173,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -45,6 +45,8 @@ mtls:
 rollmeAnnotation:
   enabled: true
 
+tolerations: []
+
 wizConnector:
   # Specifies whether a connector secret should be created
   # If createSecret is false you need to:
@@ -160,3 +162,5 @@ global:
 
   # Set to true to use FedRamp endpoints and FIPS-compliant images.
   isFedRamp: false
+
+  tolerations: []


### PR DESCRIPTION
wiz-broker currently has no tolerations in place which makes impossible to deploy it in clusters that have nodes that does not allow non-tainted pods
* Added to Values.yaml the default value for tolerations in both global.tolerations and tolerations keys
* Added coalesce function in wiz-broker-deployment