### PR TITLE
WZ-17021 - Outpost lite RDE prep

### DIFF
--- a/wiz-outpost-lite/Chart.yaml
+++ b/wiz-outpost-lite/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20241125
+version: 0.1.20241204
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-outpost-lite/templates/deployment.yaml
+++ b/wiz-outpost-lite/templates/deployment.yaml
@@ -33,9 +33,14 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}/{{ .Values.image.namePrefix}}:{{ .Values.image.tag }}{{ if .Values.agent.env }}-{{ .Values.agent.env }}{{ end }}"
+          image: "{{ .Values.image.repository }}/{{ .Values.image.namePrefix}}:{{ .Values.image.tag }}{{ .Values.image.tagSuffix }}"
           command: [ "/entrypoint"]
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.extraEnvConfigMap }}
+          envFrom:
+          - configMapRef:
+              name: {{ .Values.extraEnvConfigMap | quote }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}

--- a/wiz-outpost-lite/values.yaml
+++ b/wiz-outpost-lite/values.yaml
@@ -18,8 +18,10 @@ secret:
 image:
   repository: wizio.azurecr.io
   namePrefix: outpost-lite-runner
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.1-latest"
+  tagSuffix: ""
 
 autoUpdate: true
 
@@ -45,6 +47,7 @@ internetAccessCertificates:
   skipSslValidation: false
 
 extraEnv: {}
+extraEnvConfigMap: ""
 
 httpProxyConfiguration:
   enabled: false


### PR DESCRIPTION
- Decouple the agent env and the tag suffix to allow for controlling separately;
 If a custom chooses to pin on a specific version ('x.y.z') and they're on a different env (say gov), they'll always get 'x.y.z-gov', which might not actually exist exist
- Allow templating pull policy (we'll need IfNotPresent in dev)
- Allow injecting extra env from config map via extraEnvConfigMap
