### PR TITLE
WZ-17021 - Add ability to control termination grace period

### DIFF
--- a/wiz-outpost-lite/templates/deployment.yaml
+++ b/wiz-outpost-lite/templates/deployment.yaml
@@ -153,6 +153,7 @@ spec:
             - mountPath: /usr/local/share/ca-certificates/
               name: ca-certificate
               readOnly: true
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/wiz-outpost-lite/values.yaml
+++ b/wiz-outpost-lite/values.yaml
@@ -69,6 +69,8 @@ httpProxyConfiguration:
   #   replaceme
   #   --- END CERTIFICATE ---
 
+terminationGracePeriodSeconds: 30
+
 runners:
   container-registry:
     enabled: false
@@ -81,3 +83,4 @@ runners:
     image:
       name: outpost-lite-runner-vcs
     concurrency: 4
+    terminationGracePeriodSeconds: 300 # 5 minutes


### PR DESCRIPTION
- Increase termination grace period to 5 minutes for vcs event triggered scans
