### PR TITLE
WZ-17021 - Control concurrency in chart

### DIFF
--- a/wiz-outpost-lite/templates/deployment.yaml
+++ b/wiz-outpost-lite/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           - name: OUTPOST_LITE_RUNNER_AUTO_UPDATE
             value: "1"
           {{- end }}
+          {{- if .Values.concurrency }}
+          - name: OUTPOST_LITE_RUNNER_CONCURRENCY
+            value: "{{ .Values.concurrency }}"
+          {{- end }}
           - name: http_proxy
             valueFrom:
               secretKeyRef:

--- a/wiz-outpost-lite/values.yaml
+++ b/wiz-outpost-lite/values.yaml
@@ -24,6 +24,9 @@ image:
 
 autoUpdate: true
 
+# If set, controls the message processing concurrency of the runner
+concurrency: 0
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -77,3 +80,4 @@ runners:
     enabled: false
     image:
       name: outpost-lite-runner-vcs
+    concurrency: 4


### PR DESCRIPTION
- Add concurrency env var to chart
- Increase default of PR scans to 4
- Only include env var if the value is set, to let us alter the default in code for those unset
