### PR TITLE
k8s helm charts - make proxy great again

### DIFF
--- a/wiz-kubernetes-integration/templates/secret-proxy.yaml
+++ b/wiz-kubernetes-integration/templates/secret-proxy.yaml
@@ -1,4 +1,11 @@
+{{- if and (not (empty .Values.global.httpProxyConfiguration.httpsProxy)) (eq .Values.global.httpProxyConfiguration.enabled false) }}
+  {{- fail "Error: httpsProxy is set but httpProxyConfiguration.enabled is false. Please enable the proxy configuration or unset httpsProxy." }}
+{{- end }}
+
 {{- if and .Values.global.httpProxyConfiguration.enabled .Values.global.httpProxyConfiguration.create }}
+  {{- if hasPrefix "https://" .Values.global.httpProxyConfiguration.httpsProxy }}
+    {{- fail "Error: httpsProxy must start with 'http://', https or any other protocol is not supported." }}
+  {{- end }}
 apiVersion: v1
 kind: Secret
 type: Opaque


### PR DESCRIPTION
Changes:
1. Block https scheme in httpsProxy Rather than allowing users to install the chart and fail miserably later, we shift left the check to template render time.

2. Check if proxy is configured but is not enabled