### PR TITLE
wiz-network-analyzer - added region and fixed CA proxy

### DIFF
--- a/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-ca-from-secret.golden.yaml
+++ b/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-ca-from-secret.golden.yaml
@@ -101,6 +101,10 @@ spec:
           args:
             
             - analyze
+            - --region
+            - us-east-2
+            - --proxy-ca-dir
+            - /usr/local/share/ca-certificates
           env:
           - name: LOG_LEVEL
             value: info

--- a/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-connect-proxy.golden.yaml
+++ b/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-connect-proxy.golden.yaml
@@ -101,6 +101,10 @@ spec:
           args:
             
             - analyze
+            - --region
+            - us-east-2
+            - --proxy-ca-dir
+            - /usr/local/share/ca-certificates
           env:
           - name: LOG_LEVEL
             value: info

--- a/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-outpost.golden.yaml
+++ b/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-outpost.golden.yaml
@@ -93,6 +93,8 @@ spec:
             - analyze
             - --outpost-id
             - "0b5857fb-29e1-405e-bf69-abcd1234ab64"
+            - --region
+            - us-east-2
           env:
           - name: LOG_LEVEL
             value: info

--- a/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-transparent-proxy.golden.yaml
+++ b/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer-transparent-proxy.golden.yaml
@@ -101,6 +101,10 @@ spec:
           args:
             
             - analyze
+            - --region
+            - us-east-2
+            - --proxy-ca-dir
+            - /usr/local/share/ca-certificates
           env:
           - name: LOG_LEVEL
             value: info

--- a/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer.golden.yaml
+++ b/.circleci/tests/golden/wiz-network-analyzer/wiz-network-analyzer.golden.yaml
@@ -91,6 +91,8 @@ spec:
           args:
             
             - analyze
+            - --region
+            - us-east-2
           env:
           - name: LOG_LEVEL
             value: info

--- a/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-ca-from-secret.yaml
+++ b/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-ca-from-secret.yaml
@@ -10,3 +10,5 @@ caCertificate:
   enabled: true
   create: false
   secretName: my-ca-bundle
+
+wizRegion: "us-east-2"

--- a/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-connect-proxy.yaml
+++ b/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-connect-proxy.yaml
@@ -12,3 +12,5 @@ caCertificate:
     -----BEGIN CERTIFICATE-----
     abcd1234
     -----END CERTIFICATE-----
+
+wizRegion: "us-east-2"

--- a/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-outpost.yaml
+++ b/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-outpost.yaml
@@ -3,3 +3,5 @@ outpostId: 0b5857fb-29e1-405e-bf69-abcd1234ab64
 wizApiToken:
   clientId: "client-id"
   clientToken: "client-secret"
+
+wizRegion: "us-east-2"

--- a/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-transparent-proxy.yaml
+++ b/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer-transparent-proxy.yaml
@@ -8,3 +8,5 @@ caCertificate:
     -----BEGIN CERTIFICATE-----
     abcd1234
     -----END CERTIFICATE-----
+
+wizRegion: "us-east-2"

--- a/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer.yaml
+++ b/.circleci/tests/testfiles/wiz-network-analyzer/wiz-network-analyzer.yaml
@@ -1,3 +1,5 @@
 wizApiToken:
   clientId: "client-id"
   clientToken: "client-secret"
+
+wizRegion: "us-east-2"

--- a/wiz-network-analyzer/Chart.yaml
+++ b/wiz-network-analyzer/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for troubleshooting networking connectivity from Kuber
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 appVersion: "0.1"

--- a/wiz-network-analyzer/templates/_helpers.tpl
+++ b/wiz-network-analyzer/templates/_helpers.tpl
@@ -114,6 +114,12 @@ analyze
 --outpost-id
 "{{ .Values.outpostId }}"
 {{- end }}
+--region
+{{ .Values.wizRegion }}
+{{- if and .Values.caCertificate.enabled }}
+--proxy-ca-dir
+/usr/local/share/ca-certificates
+{{- end }}
 {{- end }}
 
 {{- define "wiz-kubernetes.pre-istio-sidecar" -}}

--- a/wiz-network-analyzer/templates/job-network-analyzer.yaml
+++ b/wiz-network-analyzer/templates/job-network-analyzer.yaml
@@ -1,3 +1,7 @@
+{{- if not .Values.wizRegion }}
+{{- fail "The 'wizRegion' parameter is mandatory and must be specified in values.yaml" }}
+{{- end }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/wiz-network-analyzer/values.yaml
+++ b/wiz-network-analyzer/values.yaml
@@ -213,3 +213,7 @@ global:
     # Leave blank for transparent proxy.
     httpsProxy: "" # URL to use as a proxy for outbound HTTPS traffic.
     noProxyAddress: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+
+# The Wiz region used for this tenant.
+# e.g. us-east-2.
+wizRegion: ""

--- a/wiz-network-analyzer/values.yaml
+++ b/wiz-network-analyzer/values.yaml
@@ -214,6 +214,6 @@ global:
     httpsProxy: "" # URL to use as a proxy for outbound HTTPS traffic.
     noProxyAddress: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
 
-# The Wiz region used for this tenant.
+# The Wiz DC AWS region used for this tenant.
 # e.g. us-east-2.
 wizRegion: ""


### PR DESCRIPTION
The wizRegion is now a mandatory parameter for the values.yaml.
Also, when a CA certificate is used, we should provide a hint to the wiz-network-analyzer such that it is captured in the final configuration output file (--proxy-ca-dir).