### PR TITLE
allow customisation of the connector delete function

### DIFF
--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -209,7 +209,9 @@ delete-kubernetes-connector
 {{ .Release.Namespace | quote }}
 --input-secret-name
 {{ include "wiz-kubernetes-connector.connectorSecretName" . | trim | quote }}
+{{- if .Values.autoCreateConnector.autoDeleteConnectorAlwaysSucceed }} 
 || true
+{{ end }}
 {{- end }}
 
 {{- define "wiz-kubernetes-connector.argsListDeleteConnector" -}}

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -22,7 +22,7 @@ spec:
   selector:
     matchLabels:
       {{- include "wiz-kubernetes-connector.selectorLabels" . | nindent 6 }}
-  backoffLimit: 1
+  backoffLimit: {{ .Values.autoCreateConnector.autoDeleteConnectorBackoffLimit }}
   template:
     metadata:
       {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -32,6 +32,8 @@ autoCreateConnector:
   enabled: true # Whether to run a Job that connects to Wiz and creates a connector
 
   autoDeleteConnectorEnabled: true # Whether to run a Job that connects to Wiz and deletes the connector on `helm uninstall`
+  autoDeleteConnectorBackoffLimit: 2 # The number of retries before considering the Job failed. `autoDeleteConnectorAlwaysSucceed` must be set to false for changes to take effect
+  autoDeleteConnectorAlwaysSucceed: true # Whether to consider the Job successful even if the connector deletion fails. If the cluster cannot reach the Wiz backend when connector deletion occurs manual connector removal in Wiz may be required.
 
   connectorName: "" # Recommended for self-managed clusters to easily identify the connector 
   clusterFlavor: "" # Possible values: EKS, AKS, GKE, OKE, OpenShift, ACK, Kubernetes (defaults to Kubernetes)


### PR DESCRIPTION
This PR is designed to allow customisation of the connector delete function that is specified in `autoCreateConnector.autoDeleteConnectorEnabled`. 

The current implementation results in an automatic successful exit code of the connector delete job, so if access to the Wiz API is temporarily unavailable this results in the connector not being removed from Wiz.

These changes (which do not modify the current defaults) allow for users of the chart to control whether the job automatically completes with an exit code of 0 and if retries should be performed, as these parameters are not currently exposed via the chart and results in charges to the pod `backoffLimit` and `args` fields.

**Current:**
```
$ helm template wiz . --set wizApiToken.secret.create=false --set wizApiToken.secret.name=bob
...
# Source: wiz-kubernetes-connector/templates/job-delete-connector.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: wiz-kubernetes-connector-delete-connector
....
spec:
...
  backoffLimit: 1
...
          args:
            - >
              wiz-broker delete-kubernetes-connector 
              --input-secrets-namespace 
              "default" 
              --input-secret-name 
              "wiz-connector"  
              || true 
              
          env:
          - name: LOG_LEVEL
            value: info
...
```

**Proposed changes:**
```
$ helm template wiz . --set autoCreateConnector.autoDeleteConnectorBackoffLimit=10 --set autoCreateConnector.autoDeleteConnectorAlwaysSucceed=false --set wizApiToken.secret.create=false --set wizApiToken.secret.name=bob
...
# Source: wiz-kubernetes-connector/templates/job-delete-connector.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: wiz-kubernetes-connector-delete-connector
...
spec:
...
  backoffLimit: 10
...
          args:
            - >
              wiz-broker delete-kubernetes-connector 
              --input-secrets-namespace 
              "default" 
              --input-secret-name 
              "wiz-connector"
          env:
          - name: LOG_LEVEL
            value: info
...
```