### PR TITLE
fix: avoid null secretTemplate in Certificate

### DIFF
--- a/wiz-admission-controller/templates/certmanager.yaml
+++ b/wiz-admission-controller/templates/certmanager.yaml
@@ -24,11 +24,11 @@ spec:
   duration: "87600h0m0s" # AC doesn't currently detect changes to the certificate and must be restarted after renewal
   renewBefore: "360h0m0s"
   secretName: {{ include "wiz-admission-controller.secretServerCert" . | quote }}
+  {{- with (coalesce .Values.webhook.secret.annotations .Values.opaWebhook.secret.annotations) }}
   secretTemplate:
-    {{- with (coalesce .Values.webhook.secret.annotations .Values.opaWebhook.secret.annotations) }}
     annotations:
       {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- end }}
   issuerRef:
     name: "selfsigned-issuer"
     kind: "Issuer"


### PR DESCRIPTION
Validation using tools like kubeconform does not pass. The error is `Check JSON formatting: jsonschema: '/spec/secretTemplate' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/certificate_v1.json#/properties/spec/properties/secretTemplate/type: expected object, but got null`