### PR TITLE
Better support for merging values in wiz-kubernetes-connector, wiz-broker, wiz-admission-controller

### DIFF
--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.12
+version: 3.7.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/cronjobmanager.yaml
+++ b/wiz-admission-controller/templates/cronjobmanager.yaml
@@ -18,12 +18,18 @@ spec:
           annotations:
             rollme.proxyHash: {{ include "wiz-admission-controller.proxyHash" . }}
             rollme.wizApiTokenHash: {{ include "wiz-admission-controller.wizApiTokenHash" . }}
-            {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+            {{- with .Values.global.podAnnotations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.podAnnotations }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           labels:
             {{- include "wiz-admission-controller-manager.labels" . | nindent 12 }}
-            {{- with (coalesce .Values.global.podLabels .Values.podLabels) }}
+            {{- with .Values.global.podLabels  }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.podLabels  }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
@@ -92,8 +98,13 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+          {{- if (or .Values.global.tolerations .Values.tolerations)}}
           tolerations:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.tolerations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.tolerations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
 {{- end }}

--- a/wiz-admission-controller/templates/deploymentauditlogs.yaml
+++ b/wiz-admission-controller/templates/deploymentauditlogs.yaml
@@ -20,7 +20,10 @@ spec:
         rollme.proxyHash: {{ include "wiz-admission-controller.proxyHash" . }}
         rollme.wizApiTokenHash: {{ include "wiz-admission-controller.wizApiTokenHash" . }}
         rollme.webhookCert: {{ include (print $.Template.BasePath "/opawebhook.yaml") . | sha256sum }}
-        {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+        {{- with .Values.global.podAnnotations  }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations  }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
@@ -28,7 +31,10 @@ spec:
         `labels` includes `selectorLabels`
         */}}
         {{- include "wiz-kubernetes-audit-log-collector.labels" . | nindent 8 }}
-        {{- with (coalesce .Values.global.podLabels .Values.podLabels) }}
+        {{- with .Values.global.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -130,8 +136,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+      {{- if (or .Values.global.tolerations .Values.tolerations)}}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/wiz-admission-controller/templates/deploymentenforcement.yaml
+++ b/wiz-admission-controller/templates/deploymentenforcement.yaml
@@ -20,7 +20,10 @@ spec:
         rollme.proxyHash: {{ include "wiz-admission-controller.proxyHash" . }}
         rollme.wizApiTokenHash: {{ include "wiz-admission-controller.wizApiTokenHash" . }}
         rollme.webhookCert: {{ include (print $.Template.BasePath "/opawebhook.yaml") . | sha256sum }}
-        {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+        {{- with .Values.global.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
@@ -28,7 +31,10 @@ spec:
         `labels` includes `selectorLabels`
         */}}
         {{- include "wiz-admission-controller-enforcement.labels" . | nindent 8 }}
-        {{- with (coalesce .Values.global.podLabels .Values.podLabels) }}
+        {{- with .Values.global.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -162,8 +168,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+      {{- if (or .Values.global.tolerations .Values.tolerations)}}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -4,7 +4,7 @@ description: Wiz Broker for tunneling http traffic to Wiz backend
 
 type: application
 
-version: 2.2.6-preview.2
+version: 2.2.6-preview.3
 appVersion: "2.6"
 
 dependencies:

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- with .Values.global.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- /* `labels` includes `selectorLabels` */}}
           {{- include "wiz-broker.labels" . | nindent 8 }}
@@ -75,6 +78,9 @@ spec:
         {{- with .Values.global.customVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.customVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -100,6 +106,9 @@ spec:
             readOnly: true
           {{- end }}
           {{- with .Values.global.customVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.customVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
           args: [
@@ -185,8 +194,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+      {{- if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -26,9 +26,12 @@ serviceAccount:
 
 podCustomEnvironmentVariablesFile: ""
 podCustomEnvironmentVariables: []
+customVolumes: []
+customVolumeMounts: []
 podAdditionalSpec: {}
-tolerations: [ ]
+tolerations: []
 skipTlsVerify: false # true indicates that the proxy's certificate should not be verified. DO NOT USE IN PRODUCTION!
+podAnnotations: {}
 
 caCertificate:
   enabled: false

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.11-preview.3
+version: 3.2.11-preview.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -271,3 +271,4 @@ refresh-token
 {{ .Capabilities.KubeVersion.Version }}
 {{- end -}}
 {{- end -}}
+

--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -39,9 +39,17 @@ spec:
   backoffLimit: 1
   template:
     metadata:
-      {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+      {{- if (or .Values.global.podAnnotations .Values.podAnnotations .Values.autoCreateConnector.podAnnotations)}}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.autoCreateConnector.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{/*
@@ -161,8 +169,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+      {{- if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -25,9 +25,17 @@ spec:
   backoffLimit: 1
   template:
     metadata:
-      {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+      {{- if (or .Values.global.podAnnotations .Values.podAnnotations .Values.autoCreateConnector.podAnnotations)}}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.autoCreateConnector.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{/*
@@ -146,9 +154,14 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+      {{- if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.global.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/wiz-kubernetes-connector/templates/job-refresh-token.yaml
+++ b/wiz-kubernetes-connector/templates/job-refresh-token.yaml
@@ -12,10 +12,27 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
+  {{- if .Values.refreshToken.cronJobAnnotations}}
+  annotations:
+    {{- with (.Values.refreshToken.cronJobAnnotations) }}
+      {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
 spec:
   schedule: "{{ .Values.refreshToken.schedule }}"
   concurrencyPolicy: Forbid  # Ensures only one job instance runs at a time
   jobTemplate:
+    metadata:
+      name: {{ include "wiz-kubernetes-connector.name" . }}-refresh-token-job
+      namespace: {{ .Release.Namespace | quote }}
+      labels:
+        {{- include "wiz-kubernetes-connector.labels" . | nindent 8 }}
+      {{- if .Values.refreshToken.jobAnnotations}}
+      annotations:
+        {{- with (.Values.refreshToken.jobAnnotations) }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       activeDeadlineSeconds: {{ .Values.refreshToken.timeoutSeconds }}
       ttlSecondsAfterFinished: {{ .Values.refreshToken.cleanupJobSeconds }}
@@ -25,7 +42,13 @@ spec:
             rollme.proxyHash: {{ include "wiz-kubernetes-connector.proxyHash" . }}
             rollme.brokerHash: {{ include "wiz-kubernetes-connector.brokerHash" . }}
             rollme.wizApiTokenHash: {{ include "wiz-kubernetes-connector.wizApiTokenHash" . }}
-            {{- with (coalesce .Values.global.podAnnotations .Values.podAnnotations) }}
+            {{- with .Values.global.podAnnotations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.podAnnotations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.refreshToken.podAnnotations }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           labels:
@@ -134,8 +157,13 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (coalesce .Values.global.tolerations .Values.tolerations) }}
+          {{- if (or .Values.global.tolerations .Values.tolerations) }}
           tolerations:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.tolerations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.tolerations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
     {{- end }}

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -40,6 +40,9 @@ refreshToken:
   schedule: "0 */12 * * *"  # Every 12 hours
   timeoutSeconds: 600 # The timeout for the refresh job in seconds - setting to 10 minutes since the job sleeps for a random amount of time.
   cleanupJobSeconds: 600 # The time in seconds after which the job should be deleted - setting to 10 minutes since the job sleeps for a random amount of time.
+  cronJobAnnotations: {}
+  jobAnnotations: {}
+  podAnnotations: {}
 
 autoCreateConnector:
   enabled: true # Whether to run a Job that connects to Wiz and creates a connector
@@ -65,6 +68,7 @@ autoCreateConnector:
   
   podCustomEnvironmentVariables: [] # Additional environment variables to add to the components Pods as pairs “name”, “value”.
   podCustomEnvironmentVariablesFile: ""
+  podAnnotations: {} # Annotations to add to the components Pods.
   podAdditionalSpec: {}
   
   customVolumes: [] # Additional volumes to add to the components Pods
@@ -175,7 +179,7 @@ resources:
 nodeSelector: {}
 
 tolerations: []
-
+podAnnotations: {}
 affinity: {}
 
 # Redirect HTTP and/or HTTPS traffic through a proxy.


### PR DESCRIPTION
Ensure labels, annotations, custom volumes, tolerations are merged between global values section, and non-global values section.
This will also support setting pod annotations for wiz-broker pods, or for wiz-kubernetes-connector pods.
For example - this will set annotations for the wiz-broker pods
```
wiz-broker:
  podAnnotations:
    brokerAnnotationKey: brokerAnnotationValue  
```

This will set annotations for the `create-connector` pods & jobs:
```
autoCreateConnector:
  podAnnotations:
    autoCreateConnectorAnnotationKey: autoCreateConnectorAnnotationValue

  createJobAnnotations:
    createConnectorJobAnnotationKey: jobAnnotationValue

  deleteJobAnnotations:
    deleteConnectorJobAnnotationKey: jobAnnotationValue
```

The `create-connector` job will get the `createJobAnnotations` annotations, the `delete-connector` job will get the `deleteJobAnnotations` annotations, while all the pods in this deployment will get the `podAnnotations`