### PR TITLE
fix: whitespace correction for secrets reader role binding

### DIFF
--- a/wiz-admission-controller/templates/serviceaccount.yaml
+++ b/wiz-admission-controller/templates/serviceaccount.yaml
@@ -70,7 +70,7 @@ roleRef:
   kind: Role
   name: {{ printf "%s-pull-secrets-reader" (include "wiz-admission-controller.serviceAccountName" .) }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
+{{ end }}
 
 
 {{- if .Values.wizManager.enabled -}}


### PR DESCRIPTION
This PR is intended to fix an issue which would cause the Kubernetes RoleBinding for the "secrets-reader" Role to become malformed when utilizing the Wiz Manager and also passing an image pull secret for image trust.

The `apiGroup` in the RoleBinding would end up becoming `apiGroup: rbac.authorization.k8s.io---`.

This is reproducible with the following `values.yaml` when rendering the manifests from the helm chart:
```
wizApiToken:
  clientId: test
  clientToken: test

imageIntegrityWebhook:
  enabled: true

imageRegistryClient:
  pullSecrets:
    - "wiz-image-pull-secret"
```

With this you can simply run `helm template wiz.io/wiz-admission-controller --values values.yml | grep -i io---` to see the mistake.