### PR TITLE
Allow disabling ttlSecondsAfterFinished for autoCreateConnector jobs

### DIFF
--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -31,7 +31,9 @@ metadata:
     {{- end }}   
 
 spec:
+  {{ if .Values.autoCreateConnector.useJobTTL }}
   ttlSecondsAfterFinished: 60
+  {{ end }}
   manualSelector: true
   selector:
     matchLabels:

--- a/wiz-kubernetes-connector/templates/job-delete-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-delete-connector.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- end }} 
 
 spec:
+  {{ if .Values.autoCreateConnector.useJobTTL }}
   ttlSecondsAfterFinished: 60
+  {{ end }}
   manualSelector: true
   selector:
     matchLabels:

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -49,6 +49,8 @@ autoCreateConnector:
 
   autoDeleteConnectorEnabled: true # Whether to run a Job that connects to Wiz and deletes the connector on `helm uninstall`
 
+  useJobTTL: true # Enable or disable the TTL (Time to Live) mechanism for automatic cleanup of finished Jobs.
+
   connectorName: "" # Recommended for self-managed clusters to easily identify the connector 
   clusterFlavor: "" # Possible values: EKS, AKS, GKE, OKE, OpenShift, ACK, Kubernetes (defaults to Kubernetes)
   apiServerEndpoint: "" # Required when not using Broker. Defaults to https://kubernetes.default.svc.cluster.local


### PR DESCRIPTION
When using ArgoCD with deletion hooks, having ttlSecondsAfterFinished field can lead to Applications being OutOfSync

https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#sync-status-with-jobsworkflows-with-time-to-live-ttl