### PR TITLE
Publish wiz-broker 2.2.7 and wiz-kubernetes-connector 3.2.12

### DIFF
--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -4,7 +4,7 @@ description: Wiz Broker for tunneling http traffic to Wiz backend
 
 type: application
 
-version: 2.2.6-preview.9
+version: 2.2.7
 appVersion: "2.6"
 
 dependencies:

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.11-preview.11
+version: 3.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,7 +27,7 @@ dependencies:
   - name: wiz-broker
     repository: https://wiz-sec.github.io/charts
 #    repository: "file://../wiz-broker" # Use this line to test the chart locally
-    version: ">=2.2.6-0"
+    version: ">=2.2.7"
     condition: wiz-broker.enabled
   - name: wiz-common
     version: "0.1.1"


### PR DESCRIPTION
wiz-broker 2.2.7 chart version:
* add global.wiz-kubernetes-connector.resources section that controls the resources of all wiz-broker & wiz-kubernetes-connector pods (WZ-65213)
* Add wiz.io/component label to wiz-broker pods (As part of ticket WZ-27761 - refresh token)
* Make sure broker affinity & node selector is populated from global values (WZ-64258)
* Better support for merging values in wiz-broker between global.values section and non global sections (WZ-54539)
* Include tolerations + global.tolerations in wiz-broker chart (WZ-63025)
* Require minimum helm version 3.6.0 as prerequisite for installing the chart (WZ-63298)
* Increase wiz-broker appVersion to version 2.6 to support refreshToken feature (In preview) (WZ-27761)


wiz-kubernetes-connector 3.2.12 chart version:
* add global.wiz-kubernetes-connector.resources section that controls the resources of all wiz-broker & wiz-kubernetes-connector pods (WZ-65213)
* Add wiz.io/component label to wiz-broker pods (As part of ticket WZ-27761 - refresh token)
* Allow disabling ttlSecondsAfterFinished for autoCreateConnector jobs (WZ-64449)
* Better support for merging values between global.values section and non global sections (WZ-54539)
* Require minimum helm version 3.6.0 as prerequisite for installing the chart (WZ-63298)
* Add support in helm chart for short lived tokens under refreshToken section in the helm chart (WZ-27761)