### PR TITLE
wiz-kubernetes-connector - Validate TargetIp is a substring of apiServerEndpoint, and does not contain http/https

### DIFF
--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/input-validations.yaml
+++ b/wiz-kubernetes-connector/templates/input-validations.yaml
@@ -1,1 +1,14 @@
 {{ include "wiz-common.requireHelm36" . }}
+
+
+{{- $targetIp := (index .Values "wiz-broker" "targetIp") -}}
+{{- $apiServerEndpoint := include "wiz-kubernetes-connector.apiServerEndpoint" . | trim -}}
+
+{{/*Ensure targetIp does not start with http:// or https://*/}}
+{{- if (or (hasPrefix "http://" $targetIp) (hasPrefix "https://" $targetIp)) }}
+  {{- fail (printf "Error: 'targetIp' must not start with 'http://' or 'https://', got '%s'." $targetIp) }}
+{{- end }}
+
+{{- if (and $targetIp $apiServerEndpoint (not (contains $targetIp $apiServerEndpoint))) }}
+{{- fail (printf "targetIp (%s) must be a substring of apiServerEndpoint (%s)" $targetIp $apiServerEndpoint) }}
+{{- end }}


### PR DESCRIPTION
Updating charts from wiz commit 2527a861c4329e7924422ecedd1b152f79ba7686