### PR TITLE
add wiz-sensor codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 /.circleci/ @wiz-sec/wiz-devops
 /.circleci/tests/ @wiz-sec/Wiz-Charts-Approvers
 /wiz-outpost-lite/**/* @yarinm
+/wiz-sensor/**/* @ariknem


### PR DESCRIPTION
Basically only the CI should push there