### PR TITLE
Add EKS Auto Mode system node toleration

### DIFF
--- a/wiz-sensor/values.yaml
+++ b/wiz-sensor/values.yaml
@@ -295,6 +295,8 @@ daemonset:
   #- key: node.ocs.openshift.io/storage
   #  value: "true"
   #  effect: NoSchedule
+  #- key: CriticalAddonsOnly
+  #  operator: Exists
 
   # Default strategy to update the daemonset
   updateStrategy:


### PR DESCRIPTION
Adding system node toleration for the new EKS Auto Mode flavor of EKS. Needs to be uncommented to schedule the Sensor on the `system` node.