### PR TITLE
add namespace to AC PDB template

### DIFF
--- a/wiz-admission-controller/templates/pod-disruption-budget.yaml
+++ b/wiz-admission-controller/templates/pod-disruption-budget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "wiz-kubernetes-audit-log-collector.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: {{ .Values.kubernetesAuditLogsWebhook.podDisruptionBudget.minAvailable }}
   maxUnavailable: {{ .Values.kubernetesAuditLogsWebhook.podDisruptionBudget.maxUnavailable }}


### PR DESCRIPTION
Include namespace in the admission controller PodDisruptionBudget template for consistency with all other resources.