### PR TITLE
WZ-59890: Put default values for all proxy keys

### DIFF
--- a/wiz-outpost-configuration/Chart.yaml
+++ b/wiz-outpost-configuration/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2025.07.07
+version: 2025.08.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-outpost-configuration/templates/httpProxyConfiguration.secret.yaml
+++ b/wiz-outpost-configuration/templates/httpProxyConfiguration.secret.yaml
@@ -13,27 +13,18 @@ metadata:
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
 data:
   {{- with .Values.httpProxyConfiguration.httpProxy }}
-  httpProxy: {{ . | b64enc | quote }}
-  http-proxy: {{ . | b64enc | quote }}
+  httpProxy: {{ . | default "" | b64enc | quote }}
+  http-proxy: {{ . | default "" | b64enc | quote }}
   {{- end }}
   {{- with .Values.httpProxyConfiguration.httpsProxy }}
-  httpsProxy: {{ . | b64enc | quote }}
-  https-proxy: {{ . | b64enc | quote }}
+  httpsProxy: {{ . | default "" | b64enc | quote }}
+  https-proxy: {{ . | default "" | b64enc | quote }}
   {{- end }}
-  {{- if .Values.httpProxyConfiguration.noProxy }}
-  no-proxy-address: {{ $noProxySpaceSeparatedList | b64enc | quote }}
-  no-proxy-address-cs: {{ $noProxyCommaSeparatedList | b64enc | quote }}
-  noProxyAddress: {{ $noProxyCommaSeparatedList | b64enc | quote }}
-  noProxyAddressSpaceSepareted: {{ $noProxySpaceSeparatedList | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.httpProxyConfiguration.caCertificate }}
-  caCertificate: {{ .Values.httpProxyConfiguration.caCertificate | b64enc | quote }}
-  {{- else }}
-  caCertificate: ""
-  {{- end }}
-  {{- if .Values.httpProxyConfiguration.clientCertificate }}
-  clientCertificate: {{ .Values.httpProxyConfiguration.clientCertificate | b64enc | quote }}
-  {{- else }}
-  clientCertificate: ""
-  {{- end }}
+
+  no-proxy-address: {{ $noProxySpaceSeparatedList | default "" | b64enc | quote }}
+  no-proxy-address-cs: {{ $noProxyCommaSeparatedList | default "" | b64enc | quote }}
+  noProxyAddress: {{ $noProxyCommaSeparatedList | default "" | b64enc | quote }}
+  noProxyAddressSpaceSepareted: {{ $noProxySpaceSeparatedList | default "" | b64enc | quote }}
+  caCertificate: {{ .Values.httpProxyConfiguration.caCertificate | default "" | b64enc | quote }}
+  clientCertificate: {{ .Values.httpProxyConfiguration.clientCertificate | default "" | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Wiz charts expect all the keys to exist in a secret containing the proxy
configuration. If some values are not present then empty strings should
be used
