### PR TITLE
Migrate CircleCI config to self-hosted runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 orbs:
-  path-filtering: circleci/path-filtering@0.1.3
+  path-filtering: circleci/path-filtering@1.1.0
   continuation: circleci/continuation@0.2.0
 
 executors:
   python:
     docker:
-      - image: cimg/python:3.10
+      - image: 197171649850.dkr.ecr.us-east-2.amazonaws.com/beyond/external/ops-python-only:3.12-main-multiarch
 
 setup: true
 
@@ -38,7 +38,7 @@ jobs:
         description: Mapping of path regular expressions to pipeline parameters and values. One mapping per line, whitespace-delimited.
         type: string
       resource_class:
-        default: small
+        default: wiz-sec/prod-generic-ci-small-amd64
         type: string
       parameters-output-path:
         default: /tmp/pipeline-parameters.json

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -41,11 +41,9 @@ parameters:
 
 executors:
   ops:
+    resource_class: wiz-sec/prod-generic-ci-small-amd64
     docker:
-      - image: dtzar/helm-kubectl:3.10.2
-  golang:
-    docker:
-      - image: golang:1.23
+      - image: 197171649850.dkr.ecr.us-east-2.amazonaws.com/beyond/external/wiz-ci:stable
 
 commands:
   upload_new_chart:


### PR DESCRIPTION
## Summary
- Migrate CircleCI config to self-hosted runners (generic-ci)
- Replace public Docker images with ECR equivalents
- Remove unused `golang` executor (dead code)

## Changes

### Setup config (`config.yml`)
- `python` executor image: `cimg/python:3.10` → ECR `ops-python-only:3.12-main-multiarch`
- `resource_class` default: `small` → `wiz-sec/prod-generic-ci-small-amd64`
- Upgrade `path-filtering` orb: `0.1.3` → `1.1.0`

### Continuation config (`continue_config.yml`)
- `ops` executor image: `dtzar/helm-kubectl:3.10.2` → ECR `wiz-ci:stable` (has helm, git, ssh)
- Added `resource_class: wiz-sec/prod-generic-ci-small-amd64` to `ops` executor
- Removed unused `golang` executor (dead code, referenced public `golang:1.23` image)

### Not changed
- No cache to replace (none used)
- No workspace to eliminate (none used)
- No contexts to modify (none used)
- `add_ssh_keys` kept as-is (project-level SSH key, works on self-hosted)
- `package_index.sh` unchanged

## Migration Checklist
- [x] All jobs on self-hosted runners (`resource_class: wiz-sec/*`)
- [x] No public Docker images (all from ECR)
- [x] No CircleCI native cache (none existed)
- [x] No persistent workspace (none existed)
- [x] No `setup_remote_docker` (none existed)
- [x] Slim runner classes selected (`prod-generic-ci-small-amd64`)

## Exceptions
- `package_and_index_charts` job only runs on `master` — cannot be validated on this PR branch (pushes to `gh-pages`). Uses same validated executor/runner as setup job.

## Related
- [WZ-104303](https://wiz-io.atlassian.net/browse/WZ-104303)

## Test Plan
- [x] Setup pipeline runs on self-hosted runner on PR branch
- [ ] `package_and_index_charts` continuation job validated after merge (master-only, production action)

[WZ-104303]: https://wiz-io.atlassian.net/browse/WZ-104303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ