### PR TITLE
fix(openshift): replace SCC users field with explicit RBAC binding

### DIFF
--- a/wiz-outpost-lite/templates/openshift.yaml
+++ b/wiz-outpost-lite/templates/openshift.yaml
@@ -29,13 +29,41 @@ supplementalGroups:
   type: RunAsAny
 seccompProfiles:
   - '*'
-users:
-- system:serviceaccount:{{ .Release.Namespace }}:sa-{{ .runner }}
+users: []
 volumes:
   - downwardAPI
   - emptyDir
   - hostPath
   - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "wiz-outpost-lite.fullname" . }}-scc
+  labels: {{- include "wiz-outpost-lite.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - {{ include "wiz-outpost-lite.fullname" . }}-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wiz-outpost-lite.fullname" . }}-scc
+  labels: {{- include "wiz-outpost-lite.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: sa-{{ .runner }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "wiz-outpost-lite.fullname" . }}-scc
+  apiGroup: rbac.authorization.k8s.io
 ---
 {{- end }}
 {{- end }}

--- a/wiz-sensor/templates/openshift.yaml
+++ b/wiz-sensor/templates/openshift.yaml
@@ -41,8 +41,7 @@ supplementalGroups:
   type: RunAsAny
 seccompProfiles:
   - "*"
-users:
-  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "wiz-sensor.serviceAccountName" . }}
+users: []
 # Keep alphabetically sorted
 volumes:
   - configMap
@@ -52,4 +51,33 @@ volumes:
   - persistentVolumeClaim
   - projected
   - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "wiz-sensor.fullname" . }}-scc
+  labels: {{- include "wiz-sensor.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - {{ include "wiz-sensor.fullname" . }}-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wiz-sensor.fullname" . }}-scc
+  labels: {{- include "wiz-sensor.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wiz-sensor.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "wiz-sensor.fullname" . }}-scc
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
The SCC users field is mutated in-place by out-of-band operations (e.g. oc adm policy add-scc-to-user) with no RBAC audit trail. On clusters running workloads such as Ironic alongside Wiz, this drift caused non-Wiz pods to bind to the Wiz SCC and have readOnlyRootFilesystem:true forced onto them at admission, resulting in crash loops.

Replace the inline users entry with users: [] and add a ClusterRole (scoped to the named SCC via resourceNames) and a ClusterRoleBinding targeting only the Wiz service account. Helm reconciliation now resets users: [] on every apply, making drift self-correcting, while the RBAC objects provide a visible, auditable binding that standard tooling can inspect and alert on.