### PR TITLE
Add Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["gh-pages"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest_static-ip
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: ./
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to build and deploy GitHub Pages from `gh-pages`.

## Test plan
- [ ] After merge + Pages `build_type` flip, `https://charts.wiz.io/index.yaml` continues to serve the Helm index
- [ ] CNAME (`charts.wiz.io`) preserved
- [ ] Subsequent CircleCI chart uploads to `gh-pages` trigger the workflow and update the site