### PR TITLE
Update openshift.yaml to honor the value for hostNetwork

### DIFF
--- a/wiz-sensor/templates/openshift.yaml
+++ b/wiz-sensor/templates/openshift.yaml
@@ -7,7 +7,9 @@ metadata:
 allowHostDirVolumePlugin: true
 allowPrivilegedContainer: true
 allowHostIPC: true
+{{- if .Values.hostNetwork }}
 allowHostNetwork: true
+{{- end }}
 allowHostPID: true
 allowHostPorts: true
 allowedCapabilities:


### PR DESCRIPTION
Just to keep this in line with the daemonset config, if hostNetwork is false, the SCC shouldn't set allowHostNetwork: true