### PR TITLE
WZ-90730: repoint CI image pulls to pull-ecr (615/wiz)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   python:
     docker:
-      - image: 197171649850.dkr.ecr.us-east-2.amazonaws.com/beyond/external/ops-python-only:3.12-main-multiarch
+      - image: 615167489761.dkr.ecr.us-east-2.amazonaws.com/wiz/external/ops-python-only:3.12-main-multiarch
 
 setup: true
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -43,7 +43,7 @@ executors:
   ops:
     resource_class: wiz-sec/prod-generic-ci-small-amd64
     docker:
-      - image: 197171649850.dkr.ecr.us-east-2.amazonaws.com/beyond/external/wiz-ci:stable
+      - image: 615167489761.dkr.ecr.us-east-2.amazonaws.com/wiz/external/wiz-ci:stable
 
 commands:
   upload_new_chart:

--- a/ae.log
+++ b/ae.log
@@ -1,3 +1,0 @@
-  WROTE .circleci/config.yml  (1 line(s))
-  WROTE .circleci/continue_config.yml  (1 line(s))
-[charts] applied 2 line(s) across 2 file(s); warnings=0

--- a/ae.log
+++ b/ae.log
@@ -1,0 +1,3 @@
+  WROTE .circleci/config.yml  (1 line(s))
+  WROTE .circleci/continue_config.yml  (1 line(s))
+[charts] applied 2 line(s) across 2 file(s); warnings=0


### PR DESCRIPTION
Repoint CircleCI executor image pulls from beyond (197171649850) to pull-ecr 615167489761/wiz, region preserved. Pulls only; push/IAM/gov untouched; images backfilled to main-ecr/615. Org-wide WZ-90730. Do not merge until CI is green.