### PR TITLE
feat(helm): evaluate template expressions in clusterDisplayName via tpl`

### DIFF
--- a/wiz-admission-controller/templates/_helpers.tpl
+++ b/wiz-admission-controller/templates/_helpers.tpl
@@ -565,9 +565,10 @@ false
   value:  "{{ coalesce .Values.opaWebhook.customErrorMessageMode .Values.customErrorMessageMode }}"
 {{- end -}}
 {{- end -}}
-{{- if coalesce .Values.global.clusterDisplayName .Values.clusterDisplayName }}
+{{- $clusterName := coalesce .Values.global.clusterDisplayName .Values.clusterDisplayName -}}
+{{- if $clusterName }}
 - name: WIZ_CLUSTER_NAME
-  value: {{ coalesce .Values.global.clusterDisplayName .Values.clusterDisplayName | quote }}
+  value: {{ tpl $clusterName . | quote }}
 {{- end }}
 {{- if .Values.prometheus.enabled }}
 # Prometheus metrics configuration

--- a/wiz-kubernetes-connector/templates/_helpers.tpl
+++ b/wiz-kubernetes-connector/templates/_helpers.tpl
@@ -142,7 +142,7 @@ create-kubernetes-connector
 --is-on-prem={{ include "wiz-kubernetes-connector.brokerEnabled" . | trim}}
 {{- with (coalesce .Values.global.clusterDisplayName .Values.autoCreateConnector.connectorName) }}
 --connector-name
-{{ . | quote }}
+{{ tpl . $ | quote }}
 {{- end }}
 {{- with .Values.autoCreateConnector.clusterFlavor }}
 --service-type

--- a/wiz-sensor/templates/daemonset-windows.yaml
+++ b/wiz-sensor/templates/daemonset-windows.yaml
@@ -145,7 +145,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SENSOR_CLUSTER_NAME
-          value: {{ coalesce .Values.global.clusterDisplayName .Values.sensorClusterName | quote }}
+          value: {{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName) . | quote }}
         {{- if .Values.startDelayRange }}
         - name: SENSOR_START_DELAY_RANGE
           value: {{ .Values.startDelayRange | quote }}

--- a/wiz-sensor/templates/daemonset.yaml
+++ b/wiz-sensor/templates/daemonset.yaml
@@ -276,7 +276,7 @@ spec:
           value: {{ .Values.tenantSuffix }}
         {{- end }}
         - name: SENSOR_CLUSTER_NAME
-          value: {{ coalesce .Values.global.clusterDisplayName .Values.sensorClusterName }}
+          value: "{{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName) . }}"
         - name: STDOUT_LOG
           value: {{ include "wiz-sensor.stdoutLogLevel" . }}
         {{- if not .Values.gkeAutopilot }}
@@ -529,7 +529,7 @@ spec:
         - name: WIZ_IMAGE_REGISTRY
           value: "{{ coalesce .Values.global.image.registry .Values.image.registry }}"
         - name: WIZ_SENSOR_CLUSTER_NAME
-          value: "{{ coalesce .Values.global.clusterDisplayName .Values.sensorClusterName }}"
+          value: "{{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName) . }}"
         - name: WIZ_HELM_VERSION
           valueFrom:
             fieldRef:

--- a/wiz-sensor/templates/daemonset.yaml
+++ b/wiz-sensor/templates/daemonset.yaml
@@ -529,7 +529,7 @@ spec:
         - name: WIZ_IMAGE_REGISTRY
           value: "{{ coalesce .Values.global.image.registry .Values.image.registry }}"
         - name: WIZ_SENSOR_CLUSTER_NAME
-          value: "{{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName) . }}"
+          value: {{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName | default "") . | quote }}
         - name: WIZ_HELM_VERSION
           valueFrom:
             fieldRef:

--- a/wiz-sensor/templates/daemonset.yaml
+++ b/wiz-sensor/templates/daemonset.yaml
@@ -276,7 +276,7 @@ spec:
           value: {{ .Values.tenantSuffix }}
         {{- end }}
         - name: SENSOR_CLUSTER_NAME
-          value: "{{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName) . }}"
+          value: {{ tpl (coalesce .Values.global.clusterDisplayName .Values.sensorClusterName | default "") . | quote }}
         - name: STDOUT_LOG
           value: {{ include "wiz-sensor.stdoutLogLevel" . }}
         {{- if not .Values.gkeAutopilot }}


### PR DESCRIPTION
### Overview

This PR wraps `clusterDisplayName`, `sensorClusterName`, and `connectorName` in the Helm `tpl` function. This allows dynamic template strings (e.g., from ArgoCD ApplicationSets) to be evaluated at deploy-time rather than rendering as literal strings.

### Backward Compatibility and Safety

* **Backward Compatible:** Standard literal strings are evaluated as plain text and render identically to previous versions.
* **Error Prevention:** Utilized the `| quote` pipeline to ensure empty or missing values are safely cast to empty strings, preventing template engine panics during evaluation.
* **Scope Preservation:** The sub-chart root contexts (`.`) are explicitly passed to preserve local/global values isolation.

---

### Changes Implemented

* **`wiz-kubernetes-connector`**: Updated `_helpers.tpl` conditional block to resolve template strings via `$clusterName` mapping.
* **`wiz-sensor`**: Updated `daemonset.yaml` environment variables (`SENSOR_CLUSTER_NAME` / `WIZ_SENSOR_CLUSTER_NAME`) to support dynamic templating using the `tpl` function combined with `| quote` handling.

---

### Testing

The following scenarios were tested locally using `helm install`:

1. **Static Strings:** Normal string input renders as standard text.
2. **Dynamic Strings:** Go templates passed via `--set-literal` evaluate successfully down to the sub-chart level.
3. **Fallback Hierarchy:** Missing global values correctly fall back to sub-chart values via `coalesce`.
4. **Empty Values:** Stripping out all cluster name values results in a successful installation with empty strings rather than throwing parsing errors.