### PR TITLE
Add `wiz-opentelemetry-exporter` to the public Helm chart index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ workflows:
             ^wiz-network-analyzer/.* wiz-network-analyzer true
             ^wiz-common/.* wiz-common true
             ^wiz-outpost-common/.* wiz-outpost-common true
+            ^wiz-opentelemetry-exporter/.* wiz-opentelemetry-exporter true
           base-revision: << pipeline.git.branch >>
           filters:
             branches:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -38,6 +38,9 @@ parameters:
   wiz-outpost-common:
     default: false
     type: boolean
+  wiz-opentelemetry-exporter:
+    default: false
+    type: boolean
 
 executors:
   ops:
@@ -79,6 +82,7 @@ jobs:
             - << pipeline.parameters.wiz-network-analyzer >>
             - << pipeline.parameters.wiz-common >>
             - << pipeline.parameters.wiz-outpost-common >>
+            - << pipeline.parameters.wiz-opentelemetry-exporter >>
           steps:
             - checkout:
                 path: ~/project
@@ -135,6 +139,11 @@ jobs:
           steps:
             - upload_new_chart:
                 package: wiz-network-analyzer
+      - when:
+          condition: << pipeline.parameters.wiz-opentelemetry-exporter >>
+          steps:
+            - upload_new_chart:
+                package: wiz-opentelemetry-exporter
       - when:
           condition: << pipeline.parameters.wiz-admission-controller >>
           steps:

--- a/wiz-opentelemetry-exporter/Chart.yaml
+++ b/wiz-opentelemetry-exporter/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for the Wiz OpenTelemetry exporter that ships Kubernet
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "0.2.0"


### PR DESCRIPTION
Onboards `wiz-opentelemetry-exporter` to the path-filtering allowlist (`config.yml`) and the `package_and_index_charts` job (`continue_config.yml`) so it gets packaged and added to the `charts.wiz.io` Helm index. Without this, the chart is released to OCI + GitHub Releases but never appears in `index.yaml`, so `helm repo update` cannot find it.