### PR TITLE
Remove pre-upgrade hook for the  job-create-connector

### DIFF
--- a/wiz-kubernetes-connector/templates/job-create-connector.yaml
+++ b/wiz-kubernetes-connector/templates/job-create-connector.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded 
     rollme.wizApiTokenHash: {{ include "wiz-kubernetes-connector.wizApiTokenHash" . }}
     rollme.proxyHash: {{ include "wiz-kubernetes-connector.proxyHash" . }}


### PR DESCRIPTION
When we perform a Helm upgrade, we receive this error in the create connector job:

```
Error: failed creating kubernetes connector: rpc error: code = Internal desc = Connector [xxxx] for this cluster already created by [xxxx], you can't create another one with a different service account. Please delete the existing connector first
```

This happens because the connector is already created by the same job during the initial installation, using the pre-install hook for the `wiz-kubernetes-connector` Helm chart.

Because `job-delete-connector` only runs on `pre-delete`, the existing connector is not removed when `job-create-connector` is triggered again during a Helm upgrade.

Since we expect the connector to be created only once during installation, `job-create-connector` should also run only once, using the pre-install hook.

**Existing Workaround**

The current workaround is to manually remove the auto-created connector before performing any Helm upgrade, but this is not ideal.

**Solution**

Removing the `pre-upgrade` hook would ensure that `job-create-connector` runs only once per Helm installation. This would solve the issue by making sure the connector is created only once during the lifecycle of the Helm installation.
