### PR TITLE
feat(wiz-admission-controller): per-component affinity/nodeSelector/tolerations

### DIFF
--- a/wiz-admission-controller/.helmignore
+++ b/wiz-admission-controller/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Chart tests (golden-file regression suite) — not part of the packaged chart
+tests/

--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.13.5-preview.1
+version: 3.14.0-preview.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/deploymentauditlogs.yaml
+++ b/wiz-admission-controller/templates/deploymentauditlogs.yaml
@@ -140,15 +140,18 @@ spec:
         {{- with .Values.global.customVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (coalesce .Values.global.nodeSelector .Values.nodeSelector) }}
+      {{- with (coalesce .Values.auditLogs.nodeSelector .Values.global.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (coalesce .Values.auditLogs.affinity .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.global.tolerations .Values.tolerations)}}
+      {{- if .Values.auditLogs.tolerations }}
+      tolerations:
+        {{- toYaml .Values.auditLogs.tolerations | nindent 8 }}
+      {{- else if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
         {{- with .Values.global.tolerations }}
           {{- toYaml . | nindent 8 }}

--- a/wiz-admission-controller/templates/deploymentenforcement.yaml
+++ b/wiz-admission-controller/templates/deploymentenforcement.yaml
@@ -195,15 +195,18 @@ spec:
         {{- with .Values.global.customVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (coalesce .Values.global.nodeSelector .Values.nodeSelector) }}
+      {{- with (coalesce .Values.enforcement.nodeSelector .Values.global.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (coalesce .Values.enforcement.affinity .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.global.tolerations .Values.tolerations)}}
+      {{- if .Values.enforcement.tolerations }}
+      tolerations:
+        {{- toYaml .Values.enforcement.tolerations | nindent 8 }}
+      {{- else if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
         {{- with .Values.global.tolerations }}
           {{- toYaml . | nindent 8 }}

--- a/wiz-admission-controller/tests/golden/README.md
+++ b/wiz-admission-controller/tests/golden/README.md
@@ -1,0 +1,56 @@
+# Golden-file tests — per-component scheduling
+
+These golden files pin the rendered output of the enforcement
+(`deploymentenforcement.yaml`) and audit-log (`deploymentauditlogs.yaml`)
+deployments for the `enforcement.*` / `auditLogs.*` scheduling change, so any
+future edit that alters `affinity` / `nodeSelector` / `tolerations` behavior is
+caught in review.
+
+## Run
+
+```bash
+helm dependency build ..            # from this dir: build wiz-common into ../charts
+./render-golden.sh                  # regenerate expected/*.golden.yaml (after an intended change)
+./render-golden.sh --check          # verify no drift (CI)
+```
+
+Two values are normalized so the goldens capture scheduling behavior only:
+`rollme.webhookCert` (sha256 of a freshly self-signed webhook cert, random each
+render) and the chart version from `Chart.yaml` (so a version bump is not
+flagged as drift).
+
+## Scenarios
+
+| Scenario | Input | What it proves |
+| --- | --- | --- |
+| `default` | no overrides | Both deployments inherit the shared default `nodeAffinity` (linux/arm64/amd64). Must stay byte-identical to the pre-change chart. |
+| `existing-customer` | HA via the shared `affinity` block only | A customer configured today via the shared block renders **identically** on the new chart (no per-component fields set) — the upgrade is a no-op. Also captures the pre-existing leak this PR fixes: the shared `podAntiAffinity` lands in **both** deployments. |
+| `per-component` | `enforcement.affinity` + `auditLogs.nodeSelector`/`tolerations` | The fix: the enforcer gets its own HA `podAntiAffinity`; the audit-log collector gets its own `nodeSelector`/`tolerations`. Neither rule leaks into the other deployment. |
+
+## Behavior summary (from the golden files)
+
+`existing-customer` (shared block — leak): the enforcer's `podAntiAffinity`
+(`app.kubernetes.io/name: wiz-admission-controller`) appears in **both**
+deployments, so audit-log pods anti-affine against enforcer pods.
+
+`per-component` (fix — no leak):
+
+```
+enforcement deployment            audit-log deployment
+  affinity:                         nodeSelector:
+    nodeAffinity: [os=linux]          dedicated: audit-logs
+    podAntiAffinity:                affinity:
+      wiz.io/component:               nodeAffinity: [os/arch]   # default, inherited
+        admission-controller-enforcer tolerations:
+      topologyKey: hostname            - key: dedicated ...
+```
+
+## Upgrade no-op proof (existing customers)
+
+Rendering `existing-customer` on `master` vs this branch, with the chart version
+held constant and the nondeterministic cert annotation normalized:
+
+```
+$ diff before.yaml after.yaml
+>>> IDENTICAL — existing customers' manifests are unchanged on upgrade.
+```

--- a/wiz-admission-controller/tests/golden/_base.values.yaml
+++ b/wiz-admission-controller/tests/golden/_base.values.yaml
@@ -1,0 +1,8 @@
+# Shared base for golden-file scenarios.
+# Fixed api-token so the rollme.wizApiTokenHash annotation is deterministic, and
+# the audit-log deployment enabled so both deployments render.
+wizApiToken:
+  clientId: "golden-test-client-id"
+  clientToken: "golden-test-client-token"
+kubernetesAuditLogsWebhook:
+  enabled: true

--- a/wiz-admission-controller/tests/golden/expected/default.golden.yaml
+++ b/wiz-admission-controller/tests/golden/expected/default.golden.yaml
@@ -1,0 +1,367 @@
+---
+# Source: wiz-admission-controller/templates/deploymentenforcement.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller
+  namespace: "default"
+  labels:
+    wiz.io/component: "admission-controller-enforcer"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: wiz-admission-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: wiz-admission-controller
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "admission-controller-enforcer"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wiz-admission-controller
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags # check opaWebhook for backward compatibility
+          - "--error-enforcement-method=AUDIT"
+          # Image integrity webhook flags
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "true"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "false"
+          
+          
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-enforcer
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-enforcer
+          - name: WIZ_MISCONFIGURATION_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"clusterExternalId":"","customErrorMessage":"","customErrorMessageMode":"","detailedErrorMessages":{"enabled":false,"format":"table"},"enabled":true,"errorEnforcementMethod":"","matchConditions":[],"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"policies":[],"policyEnforcementMethod":"","rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["CREATE","UPDATE"],"resources":["namespaces","configmaps","ingresses","services","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets"]}],"secret":{"annotations":{}},"sideEffects":"None","timeoutSeconds":8}
+          - name: WIZ_IMAGE_INTEGRITY_PATCH_IMAGE_DIGEST_ANNOTATION
+            value: "true"
+           # For running pod with read only file system we write all the cache files to /var/cache volume mount, used by image integrity hook
+          - name: TUF_ROOT
+            value: "/var/cache/.sigstore"
+          - name: AWS_ECR_CACHE_DIR
+            value: "/var/cache/.ecr"
+           ## Image registry client flags
+          - name: WIZ_REGISTRY_IGNORE_SECRET_MISSING_ERROR
+            value: "false"
+          - name: WIZ_REGISTRY_IMAGE_PULL_SECRET_RELOAD_INTERVAL
+            value: "5m"
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/cache
+            name: cache
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: cache
+          emptyDir: {}
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+---
+# Source: wiz-admission-controller/templates/deploymentauditlogs.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller-audit-log-collector
+  namespace: "default"
+  labels:
+    wiz.io/component: "kubernetes-audit-log-collector"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "kubernetes-audit-log-collector"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags
+          - "--error-enforcement-method=AUDIT"
+          - "--policy-enforcement-method=AUDIT"
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "true"
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "false"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-kdr
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-kdr
+          - name: WIZ_KUBERNETES_AUDIT_LOG_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"enabled":true,"matchConditions":[],"nameOverride":"","namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["*"],"resources":["namespaces","secrets","configmaps","storageclasses","persistentvolumes","persistentvolumeclaims","controllerrevisions","ingresses","services","networkpolicies","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets","replicationcontrollers","selfsubjectrulesreviews","selfsubjectreviews","pods/exec","pods/portforward","pods/attach","clusterroles","roles","rolebindings","clusterrolebindings","serviceaccounts"]},{"apiGroups":["*"],"apiVersions":["*"],"operations":["DELETE"],"resources":["events"]}],"sideEffects":"None","timeoutSeconds":8}
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64

--- a/wiz-admission-controller/tests/golden/expected/existing-customer.golden.yaml
+++ b/wiz-admission-controller/tests/golden/expected/existing-customer.golden.yaml
@@ -1,0 +1,393 @@
+---
+# Source: wiz-admission-controller/templates/deploymentenforcement.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller
+  namespace: "default"
+  labels:
+    wiz.io/component: "admission-controller-enforcer"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: wiz-admission-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: wiz-admission-controller
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "admission-controller-enforcer"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wiz-admission-controller
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags # check opaWebhook for backward compatibility
+          - "--error-enforcement-method=AUDIT"
+          # Image integrity webhook flags
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "true"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "false"
+          
+          
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-enforcer
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-enforcer
+          - name: WIZ_MISCONFIGURATION_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"clusterExternalId":"","customErrorMessage":"","customErrorMessageMode":"","detailedErrorMessages":{"enabled":false,"format":"table"},"enabled":true,"errorEnforcementMethod":"","matchConditions":[],"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"policies":[],"policyEnforcementMethod":"","rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["CREATE","UPDATE"],"resources":["namespaces","configmaps","ingresses","services","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets"]}],"secret":{"annotations":{}},"sideEffects":"None","timeoutSeconds":8}
+          - name: WIZ_IMAGE_INTEGRITY_PATCH_IMAGE_DIGEST_ANNOTATION
+            value: "true"
+           # For running pod with read only file system we write all the cache files to /var/cache volume mount, used by image integrity hook
+          - name: TUF_ROOT
+            value: "/var/cache/.sigstore"
+          - name: AWS_ECR_CACHE_DIR
+            value: "/var/cache/.ecr"
+           ## Image registry client flags
+          - name: WIZ_REGISTRY_IGNORE_SECRET_MISSING_ERROR
+            value: "false"
+          - name: WIZ_REGISTRY_IMAGE_PULL_SECRET_RELOAD_INTERVAL
+            value: "5m"
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/cache
+            name: cache
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: cache
+          emptyDir: {}
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      nodeSelector:
+        workload: wiz
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: wiz-admission-controller
+            topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: wiz
+---
+# Source: wiz-admission-controller/templates/deploymentauditlogs.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller-audit-log-collector
+  namespace: "default"
+  labels:
+    wiz.io/component: "kubernetes-audit-log-collector"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "kubernetes-audit-log-collector"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags
+          - "--error-enforcement-method=AUDIT"
+          - "--policy-enforcement-method=AUDIT"
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "true"
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "false"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-kdr
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-kdr
+          - name: WIZ_KUBERNETES_AUDIT_LOG_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"enabled":true,"matchConditions":[],"nameOverride":"","namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["*"],"resources":["namespaces","secrets","configmaps","storageclasses","persistentvolumes","persistentvolumeclaims","controllerrevisions","ingresses","services","networkpolicies","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets","replicationcontrollers","selfsubjectrulesreviews","selfsubjectreviews","pods/exec","pods/portforward","pods/attach","clusterroles","roles","rolebindings","clusterrolebindings","serviceaccounts"]},{"apiGroups":["*"],"apiVersions":["*"],"operations":["DELETE"],"resources":["events"]}],"sideEffects":"None","timeoutSeconds":8}
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      nodeSelector:
+        workload: wiz
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: wiz-admission-controller
+            topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: wiz

--- a/wiz-admission-controller/tests/golden/expected/per-component.golden.yaml
+++ b/wiz-admission-controller/tests/golden/expected/per-component.golden.yaml
@@ -1,0 +1,375 @@
+---
+# Source: wiz-admission-controller/templates/deploymentenforcement.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller
+  namespace: "default"
+  labels:
+    wiz.io/component: "admission-controller-enforcer"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: wiz-admission-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: wiz-admission-controller
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "admission-controller-enforcer"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wiz-admission-controller
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags # check opaWebhook for backward compatibility
+          - "--error-enforcement-method=AUDIT"
+          # Image integrity webhook flags
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "true"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "false"
+          
+          
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-enforcer
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-enforcer
+          - name: WIZ_MISCONFIGURATION_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"clusterExternalId":"","customErrorMessage":"","customErrorMessageMode":"","detailedErrorMessages":{"enabled":false,"format":"table"},"enabled":true,"errorEnforcementMethod":"","matchConditions":[],"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"policies":[],"policyEnforcementMethod":"","rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["CREATE","UPDATE"],"resources":["namespaces","configmaps","ingresses","services","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets"]}],"secret":{"annotations":{}},"sideEffects":"None","timeoutSeconds":8}
+          - name: WIZ_IMAGE_INTEGRITY_PATCH_IMAGE_DIGEST_ANNOTATION
+            value: "true"
+           # For running pod with read only file system we write all the cache files to /var/cache volume mount, used by image integrity hook
+          - name: TUF_ROOT
+            value: "/var/cache/.sigstore"
+          - name: AWS_ECR_CACHE_DIR
+            value: "/var/cache/.ecr"
+           ## Image registry client flags
+          - name: WIZ_REGISTRY_IGNORE_SECRET_MISSING_ERROR
+            value: "false"
+          - name: WIZ_REGISTRY_IMAGE_PULL_SECRET_RELOAD_INTERVAL
+            value: "5m"
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/cache
+            name: cache
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: cache
+          emptyDir: {}
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                wiz.io/component: admission-controller-enforcer
+            topologyKey: kubernetes.io/hostname
+---
+# Source: wiz-admission-controller/templates/deploymentauditlogs.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ac-wiz-admission-controller-audit-log-collector
+  namespace: "default"
+  labels:
+    wiz.io/component: "kubernetes-audit-log-collector"
+    helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+    app.kubernetes.io/chartName: wiz-admission-controller
+    app.kubernetes.io/instance: ac
+    app.kubernetes.io/version: "2.12"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/chartName: wiz-admission-controller
+      app.kubernetes.io/instance: ac
+      app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+  template:
+    metadata:
+      annotations:
+        rollme.proxyHash: 87ac4cfc477c5fb7044983b253c60009e1ca9c2823574cf5353b6e8ce9f3c2b4
+        rollme.wizApiTokenHash: 91fd9937400bae0e8b2c253d65bcd1f49779d8fa7fd97bb061a24cf9e779e1e0
+        rollme.webhookCert: __NONDETERMINISTIC__
+      labels:
+        wiz.io/component: "kubernetes-audit-log-collector"
+        
+        helm.sh/chart: wiz-admission-controller-__CHART_VERSION__
+        app.kubernetes.io/chartName: wiz-admission-controller
+        app.kubernetes.io/instance: ac
+        app.kubernetes.io/version: "2.12"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ac-wiz-admission-controller-audit-log-collector
+    spec:
+      serviceAccountName: ac-wiz-admission-controller
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: wiz-admission-controller
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: wiziopublic.azurecr.io/wiz-app/wiz-admission-controller:2.12
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 10250
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            timeoutSeconds: 300
+          command:
+          - "/usr/bin/wiz-admission-controller"
+          # Cluster identification flags
+          # Server flags
+          - "--port=10250"
+          - "--tls-private-key-file=/var/server-certs/tls.key"
+          - "--tls-cert-file=/var/server-certs/tls.crt"
+          - "--readiness-port=8000"
+          # Kubernetes API server flags
+          - "--namespace-cache-ttl=10m"
+          # Webhook flags
+          - "--error-enforcement-method=AUDIT"
+          - "--policy-enforcement-method=AUDIT"
+          env:
+          - name: CLI_FILES_AS_ARGS
+            value: "/var/api-client/clientToken,/var/api-client/clientId"
+          - name: WIZ_ENV
+            value: 
+          - name: LOG_LEVEL
+            value: info
+          - name: WIZ_RUNTIME_METADATA_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WIZ_RUNTIME_METADATA_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: WIZ_TERMINATION_GRACE_PERIOD
+            value: "60s"
+          - name: WIZ_CRD_CACHE_ENABLED
+            value: "true"
+          - name: WIZ_CRD_CACHE_MAX_AGE
+            value: "12h"
+          - name: WIZ_CHART_VERSION
+            value: "__CHART_VERSION__"
+          - name: WIZ_GLOBAL_LEADER_LEASE_NAME
+            value: ac-wiz-admission-controller-global-lease
+          - name: WIZ_SCRAPE_API_SERVER_METRICS_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_ENABLED
+            value: "true"
+          - name: WIZ_SELFLOOP_PROBE_LABEL
+            value: "wiz.io/self-loop-probe"
+          # Webhook enabled flags
+          - name: WIZ_KUBERNETES_AUDIT_LOGS_ENABLED
+            value: "true"
+          - name: WIZ_MISCONFIGURATION_ENABLED
+            value: "false"
+          - name: WIZ_IMAGE_INTEGRITY_ENABLED
+            value: "false"
+          - name: WIZ_CRD_CACHE_LEADER_LOCK_ID
+            value: ac-wiz-admission-controller-crd-cache-kdr
+          - name: WIZ_CRD_CACHE_NAME_PREFIX
+            value: ac-wiz-admission-controller-cache-kdr
+          - name: WIZ_KUBERNETES_AUDIT_LOG_WEBHOOK_CONFIG
+            value: |
+              {"additionalRules":[],"enabled":true,"matchConditions":[],"nameOverride":"","namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","kube-node-lease","wiz"]}]},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"rules":[{"apiGroups":["*"],"apiVersions":["*"],"operations":["*"],"resources":["namespaces","secrets","configmaps","storageclasses","persistentvolumes","persistentvolumeclaims","controllerrevisions","ingresses","services","networkpolicies","pods","deployments","jobs","cronjobs","replicasets","statefulsets","daemonsets","replicationcontrollers","selfsubjectrulesreviews","selfsubjectreviews","pods/exec","pods/portforward","pods/attach","clusterroles","roles","rolebindings","clusterrolebindings","serviceaccounts"]},{"apiGroups":["*"],"apiVersions":["*"],"operations":["DELETE"],"resources":["events"]}],"sideEffects":"None","timeoutSeconds":8}
+          ## Enable debug webhook that only logs the request
+          resources:
+            {}
+          volumeMounts:
+          - name: api-client
+            mountPath: /var/api-client
+            readOnly: true
+          - mountPath: /var/server-certs
+            name: server-certs
+            readOnly: true
+      volumes:
+        - name: api-client
+          secret:
+            secretName: ac-api-token
+        - name: server-certs
+          secret:
+            defaultMode: 444
+            secretName: ac-wiz-admission-controller-cert
+      nodeSelector:
+        dedicated: audit-logs
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: audit-logs

--- a/wiz-admission-controller/tests/golden/render-golden.sh
+++ b/wiz-admission-controller/tests/golden/render-golden.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Golden-file regression tests for the per-component scheduling change.
+#
+# Renders templates/deploymentenforcement.yaml + templates/deploymentauditlogs.yaml
+# for each scenario in scenarios/ and compares against expected/<scenario>.golden.yaml.
+#
+#   ./render-golden.sh            # regenerate the golden files (after an intended change)
+#   ./render-golden.sh --check    # verify no drift (CI)
+#
+# Prereqs: helm, and chart deps present (`helm dependency build <chart>`).
+#
+# Two nondeterministic/version-coupled values are normalized so the goldens
+# capture scheduling behavior only:
+#   - rollme.webhookCert  (sha256 of a freshly self-signed webhook cert)
+#   - the chart version    (from Chart.yaml, so a version bump is not spurious drift)
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # wiz-admission-controller/
+TESTS_DIR="$CHART_DIR/tests/golden"
+BASE="$TESTS_DIR/_base.values.yaml"
+SCEN_DIR="$TESTS_DIR/scenarios"
+EXP_DIR="$TESTS_DIR/expected"
+DEPLOYMENTS=(-s templates/deploymentenforcement.yaml -s templates/deploymentauditlogs.yaml)
+MODE="${1:-regen}"
+
+CHART_VERSION="$(awk '/^version:/{print $2; exit}' "$CHART_DIR/Chart.yaml")"
+
+render() {
+  local scenario="$1"
+  helm template ac "$CHART_DIR" -f "$BASE" -f "$SCEN_DIR/${scenario}.values.yaml" "${DEPLOYMENTS[@]}" 2>/dev/null \
+    | sed -E \
+        -e "s/(rollme\.webhookCert:).*/\1 __NONDETERMINISTIC__/" \
+        -e "s/wiz-admission-controller-${CHART_VERSION}/wiz-admission-controller-__CHART_VERSION__/g" \
+        -e "s/\"${CHART_VERSION}\"/\"__CHART_VERSION__\"/g"
+}
+
+mkdir -p "$EXP_DIR"
+fail=0
+for f in "$SCEN_DIR"/*.values.yaml; do
+  name="$(basename "$f" .values.yaml)"
+  out="$EXP_DIR/${name}.golden.yaml"
+  if [[ "$MODE" == "--check" ]]; then
+    if diff -u "$out" <(render "$name") >/dev/null 2>&1; then
+      echo "OK:    $name"
+    else
+      echo "DRIFT: $name  (run tests/golden/render-golden.sh to regenerate)"
+      diff -u "$out" <(render "$name") || true
+      fail=1
+    fi
+  else
+    render "$name" > "$out"
+    echo "wrote  $out"
+  fi
+done
+exit $fail

--- a/wiz-admission-controller/tests/golden/scenarios/default.values.yaml
+++ b/wiz-admission-controller/tests/golden/scenarios/default.values.yaml
@@ -1,0 +1,5 @@
+# Scenario: default (no scheduling overrides).
+# Both deployments inherit the shared default affinity (linux/arm64/amd64
+# nodeAffinity). This is the baseline that must remain byte-identical to the
+# pre-change chart.
+{}

--- a/wiz-admission-controller/tests/golden/scenarios/existing-customer.values.yaml
+++ b/wiz-admission-controller/tests/golden/scenarios/existing-customer.values.yaml
@@ -1,0 +1,37 @@
+# Scenario: existing customer on the CURRENT chart.
+#
+# Represents a customer who configured HA today via the SHARED affinity block
+# (the only mechanism available before this change). With no per-component fields
+# set, the new chart renders this IDENTICALLY to the old chart — proving the
+# upgrade is a no-op (see tests/golden/README.md for the master-vs-branch diff).
+#
+# It also captures the pre-existing limitation this PR fixes: the shared
+# podAntiAffinity is injected into BOTH deployments, so the audit-log pods
+# anti-affine against ENFORCER pods (app.kubernetes.io/name = the enforcer),
+# not their own replicas.
+nodeSelector:
+  workload: wiz
+tolerations:
+  - key: dedicated
+    operator: Equal
+    value: wiz
+    effect: NoSchedule
+affinity:
+  # Customer re-includes the default nodeAffinity because overriding `affinity`
+  # replaces the whole object.
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values: [linux]
+            - key: kubernetes.io/arch
+              operator: In
+              values: [arm64, amd64]
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: wiz-admission-controller

--- a/wiz-admission-controller/tests/golden/scenarios/per-component.values.yaml
+++ b/wiz-admission-controller/tests/golden/scenarios/per-component.values.yaml
@@ -1,0 +1,28 @@
+# Scenario: the fix — independent scheduling per component.
+#
+# The enforcer gets an HA podAntiAffinity that spreads only ITS replicas across
+# nodes; the audit-log collector gets its own nodeSelector + tolerations. Neither
+# rule leaks into the other deployment.
+enforcement:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values: [linux]
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              wiz.io/component: admission-controller-enforcer
+auditLogs:
+  nodeSelector:
+    dedicated: audit-logs
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: audit-logs
+      effect: NoSchedule

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -678,6 +678,36 @@ affinity:
                 - arm64
                 - amd64
 
+# Per-component scheduling overrides.
+#
+# By default the shared `nodeSelector`, `tolerations`, and `affinity` above are
+# applied identically to BOTH the enforcement and the audit-log deployments. Set
+# the blocks below to give a component its own scheduling rules — for example a
+# `podAntiAffinity` that spreads only that deployment's replicas across nodes for
+# High Availability, without the rule leaking into the other deployment.
+#
+# Precedence (per field, per component):
+#   <component>.affinity     overrides   affinity
+#   <component>.nodeSelector overrides   global.nodeSelector / nodeSelector
+#   <component>.tolerations  overrides   global.tolerations + tolerations
+#
+# Leave a field null (the default) to inherit the shared value unchanged, so
+# existing installations render identically and are unaffected.
+#
+# NOTE: `affinity` is a single object, so setting `<component>.affinity` REPLACES
+# the shared affinity for that component — including the default
+# linux/arm64/amd64 nodeAffinity above. If you override affinity, re-include
+# those nodeAffinity terms unless you intend to drop them.
+enforcement:
+  affinity: null
+  nodeSelector: null
+  tolerations: null
+
+auditLogs:
+  affinity: null
+  nodeSelector: null
+  tolerations: null
+
 probes: # Probes config for the container
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 # Note that httpGet already configured in the deployment.yaml


### PR DESCRIPTION
## User-Facing Impact

- [x] User-Facing Change: adds **optional** per-component scheduling controls to the `wiz-admission-controller` chart. No change to default behavior.

## Problem

The enforcement (`deploymentenforcement.yaml`) and audit-log (`deploymentauditlogs.yaml`) deployments share a **single** scheduling configuration:

- `nodeSelector` ← `coalesce .Values.global.nodeSelector .Values.nodeSelector`
- `affinity` ← `.Values.affinity`
- `tolerations` ← `.Values.global.tolerations` + `.Values.tolerations`

Because the same block is rendered into **both** deployments, customers cannot configure per-deployment High Availability. A `podAntiAffinity` written to spread the *enforcer* replicas is injected verbatim into the *audit-log* deployment, so audit-log pods evaluate their anti-affinity against **enforcer** pods instead of their own replicas (and vice-versa). There is no way to say "only separate replicas of *this* Deployment".

## Change

Add optional, per-component override blocks in `values.yaml`:

```yaml
enforcement:
  affinity: null
  nodeSelector: null
  tolerations: null

auditLogs:
  affinity: null
  nodeSelector: null
  tolerations: null
```

Both deployment templates now resolve each field with the component override taking precedence, falling back to the existing shared value when unset:

- `affinity`     → `coalesce .Values.<component>.affinity .Values.affinity`
- `nodeSelector` → `coalesce .Values.<component>.nodeSelector .Values.global.nodeSelector .Values.nodeSelector`
- `tolerations`  → `.Values.<component>.tolerations` if set, else the existing `global + local` concatenation

## Backward compatibility

**When the new fields are unset (the default), rendering is a byte-identical no-op.** Existing installations are unaffected; upgrading does not restart pods due to this change.

Proof (`helm template` of both deployments, before vs after, chart version held constant, the nondeterministic self-signed-cert annotation excluded):

```
$ diff before.yaml after.yaml
>>> IDENTICAL — pure no-op when enforcement.*/auditLogs.* are unset
```

New behavior with `enforcement.affinity` (HA) + independent `auditLogs.nodeSelector`/`tolerations`:

```
ENFORCEMENT deployment:            AUDIT-LOG deployment:
  affinity:                          nodeSelector:
    podAntiAffinity:                   dedicated: audit-logs
      ...                            affinity:
      wiz.io/component:                nodeAffinity:        # default, inherited
        admission-controller-enforcer    kubernetes.io/os / arch
      topologyKey:                     tolerations:
        kubernetes.io/hostname           - key: dedicated ...
```

The enforcer gets only its own `podAntiAffinity`; the audit-log deployment keeps the **default** `nodeAffinity` and its own `nodeSelector`/`tolerations`. No cross-leakage.

## ⚠️ Note on `affinity` replace semantics

`affinity` is a single object, so setting `enforcement.affinity` / `auditLogs.affinity` **replaces** the shared affinity for that component — including the default `linux/arm64/amd64` `nodeAffinity` shipped in `values.yaml`. This matches the existing behavior of overriding `.Values.affinity` today, and is documented inline in `values.yaml`: if you override a component's affinity, re-include the OS/arch `nodeAffinity` terms unless you intend to drop them. (Open to deep-merging the default `nodeAffinity` instead — see open questions.)

## How to test

```bash
cd wiz-admission-controller
helm dependency build .
helm lint .
# no-op: render both deployments with default values, compare to master — identical
# override: -f a values file setting enforcement.affinity / auditLogs.* — see per-component isolation
```

## Open questions for the reviewer

1. **Naming** — this follows the request's proposed `enforcement.*` / `auditLogs.*` top-level keys. Note audit config otherwise lives under `kubernetesAuditLogsWebhook:`; would you prefer nesting the scheduling overrides there for consistency?
2. **`affinity` semantics** — keep replace (current, consistent with `.Values.affinity`) or deep-merge the default `nodeAffinity` so overrides can't accidentally drop the OS/arch guard?
3. **`topologySpreadConstraints`** — the chart doesn't expose these today; they're arguably the safer primitive for "spread replicas of this deployment". Want them added in the same PR or a follow-up?
4. **Version bump** — bumped `3.13.5-preview.1` → `3.14.0-preview.1` (additive feature). Adjust to match your release process if needed.

> Proposal PR for review — happy to link a WZ Feature Request and adjust naming/semantics per the answers above.
