### PR TITLE
feat(wiz-admission-controller): per-component affinity/nodeSelector/tolerations

### DIFF
--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.13.5-preview.1
+version: 3.14.0-preview.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/deploymentauditlogs.yaml
+++ b/wiz-admission-controller/templates/deploymentauditlogs.yaml
@@ -140,15 +140,19 @@ spec:
         {{- with .Values.global.customVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (coalesce .Values.global.nodeSelector .Values.nodeSelector) }}
+      {{- $auditLogs := .Values.auditLogs | default dict }}
+      {{- with (coalesce $auditLogs.nodeSelector .Values.global.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (coalesce $auditLogs.affinity .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.global.tolerations .Values.tolerations)}}
+      {{- if $auditLogs.tolerations }}
+      tolerations:
+        {{- toYaml $auditLogs.tolerations | nindent 8 }}
+      {{- else if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
         {{- with .Values.global.tolerations }}
           {{- toYaml . | nindent 8 }}

--- a/wiz-admission-controller/templates/deploymentenforcement.yaml
+++ b/wiz-admission-controller/templates/deploymentenforcement.yaml
@@ -195,15 +195,19 @@ spec:
         {{- with .Values.global.customVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (coalesce .Values.global.nodeSelector .Values.nodeSelector) }}
+      {{- $enforcement := .Values.enforcement | default dict }}
+      {{- with (coalesce $enforcement.nodeSelector .Values.global.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (coalesce $enforcement.affinity .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.global.tolerations .Values.tolerations)}}
+      {{- if $enforcement.tolerations }}
+      tolerations:
+        {{- toYaml $enforcement.tolerations | nindent 8 }}
+      {{- else if (or .Values.global.tolerations .Values.tolerations) }}
       tolerations:
         {{- with .Values.global.tolerations }}
           {{- toYaml . | nindent 8 }}

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -678,6 +678,37 @@ affinity:
                 - arm64
                 - amd64
 
+# Scheduling settings for each component.
+#
+# By default, the shared `nodeSelector`, `tolerations`, and `affinity` above are
+# used for BOTH deployments (the enforcement one and the audit-log one). Use the
+# blocks below to give one component its own scheduling rules. For example, you
+# can add a `podAntiAffinity` that spreads the replicas of only that deployment
+# across nodes for High Availability. The rule will not affect the other
+# deployment.
+#
+# For each field, the component value is used first, then the shared one:
+#   <component>.affinity     is used instead of   affinity
+#   <component>.nodeSelector is used instead of   global.nodeSelector / nodeSelector
+#   <component>.tolerations  is used instead of   global.tolerations + tolerations
+#
+# Keep a field as null (the default) to use the shared value. Then existing
+# installations do not change.
+#
+# NOTE: `affinity` is one object. If you set `<component>.affinity`, it fully
+# replaces the shared affinity for that component. This also removes the default
+# linux/arm64/amd64 nodeAffinity above. If you set your own affinity, add those
+# nodeAffinity rules again, unless you want to remove them.
+enforcement:
+  affinity: null
+  nodeSelector: null
+  tolerations: null
+
+auditLogs:
+  affinity: null
+  nodeSelector: null
+  tolerations: null
+
 probes: # Probes config for the container
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 # Note that httpGet already configured in the deployment.yaml


### PR DESCRIPTION
## User-Facing Impact

- [x] User-Facing Change: adds **optional** per-component scheduling settings to the `wiz-admission-controller` chart. Default behavior does not change.

## Problem

The enforcement (`deploymentenforcement.yaml`) and audit-log (`deploymentauditlogs.yaml`) deployments use the **same** scheduling settings:

- `nodeSelector` ← `coalesce .Values.global.nodeSelector .Values.nodeSelector`
- `affinity` ← `.Values.affinity`
- `tolerations` ← `.Values.global.tolerations` + `.Values.tolerations`

The same block goes into **both** deployments. Because of this, a customer cannot set up High Availability for one deployment on its own. If you write a `podAntiAffinity` to spread the *enforcer* replicas, the same rule is also added to the *audit-log* deployment. So the audit-log pods try to move away from the *enforcer* pods, not from their own replicas.

## Change

Add optional per-component blocks in `values.yaml`:

```yaml
enforcement:
  affinity: null
  nodeSelector: null
  tolerations: null

auditLogs:
  affinity: null
  nodeSelector: null
  tolerations: null
```

Both templates now pick each field like this. The component value is used first. If it is not set, the shared value is used:

- `affinity`     → `coalesce $component.affinity .Values.affinity`
- `nodeSelector` → `coalesce $component.nodeSelector .Values.global.nodeSelector .Values.nodeSelector`
- `tolerations`  → `$component.tolerations` if set, otherwise the current `global + local` list

Each block is also cleaned with `default dict`. So if a block is null (`enforcement: null` / `auditLogs: null`), the chart uses the shared values and does not fail to render.

## Backward compatibility

When the new fields are not set (the default), both deployments render **exactly the same** as before. I checked this with `helm template` on both deployments against `master` (ignoring the chart-version label and the random webhook-cert annotation). The scheduling change adds **no** difference.

> Note: like any chart release, the version bump changes the pod template (the `helm.sh/chart` label and a version env var are in `spec.template`). So an upgrade does one **normal rolling restart**, and the pods are placed again on equal nodes. This is standard release behavior, not an effect of the scheduling change.

## Note about `affinity` replace behavior

`affinity` is one object. If you set `enforcement.affinity` / `auditLogs.affinity`, it **replaces** the shared affinity for that component. This also removes the default `linux/arm64/amd64` `nodeAffinity` from `values.yaml`. This works the same way as overriding `.Values.affinity` today, and it is explained in `values.yaml`.

## Open questions for the reviewer

1. **Naming** — this uses the `enforcement.*` / `auditLogs.*` names from the request. But the other audit-log settings live under `kubernetesAuditLogsWebhook:`. Do you prefer to put the scheduling settings there, to keep them together?
2. **`affinity` behavior** — keep "replace" (current), or merge the default `nodeAffinity` so an override cannot remove the OS/arch rule by mistake?
3. **`topologySpreadConstraints`** — the chart does not support these today. They are often a safer way to spread replicas. Add them in this PR, or in a later one?
4. **Version bump** — I changed `3.13.5-preview.1` → `3.14.0-preview.1`. Please change it if your release process needs a different number.

> This is a proposal PR for review. I can link a WZ Feature Request and change the naming or behavior based on your answers. Tested live on EKS + Argo CD (see comment).
