### PR TITLE
feat: add seccompProfile RuntimeDefault to default security contexts

### DIFF
--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -591,7 +591,9 @@ serviceAccount:
 podAnnotations: {} # Annotations to add to the components Pods.
 podLabels: {} # Labels to add to the components Pods.
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 podCustomEnvironmentVariables: [] # Additional environment variables to add to the components Pods as pairs “name”, “value”.
 
@@ -608,6 +610,8 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -233,6 +233,8 @@ global:
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 10000
+    seccompProfile:
+      type: RuntimeDefault
 
   securityContext:
     runAsNonRoot: true
@@ -240,6 +242,8 @@ global:
     readOnlyRootFilesystem: true
     runAsGroup: 10000
     runAsUser: 10000
+    seccompProfile:
+      type: RuntimeDefault
     capabilities:
       drop:
         - ALL

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -319,6 +319,8 @@ global:
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 10000
+    seccompProfile:
+      type: RuntimeDefault
 
   securityContext:
     runAsNonRoot: true
@@ -326,6 +328,8 @@ global:
     readOnlyRootFilesystem: true
     runAsGroup: 10000
     runAsUser: 10000
+    seccompProfile:
+      type: RuntimeDefault
     capabilities:
       drop:
         - ALL


### PR DESCRIPTION
Add seccompProfile.type: RuntimeDefault to podSecurityContext and securityContext defaults in all three charts (wiz-kubernetes-connector, wiz-broker, wiz-admission-controller).

This makes the charts compatible with Kubernetes restricted Pod Security Standard out of the box, without requiring users to override security contexts via lowPrivilegePodSecurityPolicy.

The change is backward-compatible — seccompProfile is supported since Kubernetes 1.19 and RuntimeDefault is the container runtime's default syscall filter (no functional change for existing deployments).

When the cluster namespace has label pod-security.kubernetes.io/enforce: restricted. The restricted PSA requires seccompProfile.type: RuntimeDefault on all pods. The Wiz chart's default security context sets runAsNonRoot, drop ALL capabilities, etc. — but doesn't include seccompProfile. That one missing field caused Kubernetes to reject the wiz pods in our case.